### PR TITLE
日本語化と機能拡張

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Run Log</title>
+  <title>ギャラクシーズホールド運行管理</title>
   <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="styles.css">
   <script src="main.esc.js" defer></script>
@@ -11,23 +11,25 @@
 </head>
 <body>
   <header>
-    <h1>Run Log</h1>
+    <h1>ギャラクシーズホールド運行管理</h1>
   </header>
   <div class="layout">
     <nav>
       <button id="toggleTripBtn" class="start" onclick="toggleTrip()">
-        <span id="toggleLabel">Start</span>
+        <span id="toggleLabel">運行開始</span>
       </button>
-      <button id="btnNewLog" onclick="showForm()">New Log</button>
-      <button id="btnList" onclick="showList()">List</button>
-      <button id="btnSummary" onclick="showSummary()">Summary</button>
-      <button id="btnExport" onclick="exportCSV()">Export CSV</button>
-      <button id="btnMaintenance" onclick="showMaintenanceList()">Maintenance</button>
+      <button id="btnNewLog" onclick="showForm()">新規記録</button>
+      <button id="btnList" onclick="showList()">一覧</button>
+      <button id="btnSummary" onclick="showSummary()">集計</button>
+      <button id="btnDaily" onclick="showDailyReport()">日報</button>
+      <button id="btnExport" onclick="exportCSV()">CSV出力</button>
+      <button id="btnMaintenance" onclick="showMaintenanceList()">整備記録</button>
 
-      <button id="btnLoad" onclick="recordEvent('Load')">Load</button>
-      <button id="btnUnload" onclick="recordEvent('Unload')">Unload</button>
-      <button id="btnFuel" onclick="recordFuelEvent()">Fuel</button>
-      <button id="btnBreak" onclick="recordEvent('Break')">Break</button>
+      <button id="btnLoad" onclick="recordEvent('Load')">積み込み</button>
+      <button id="btnUnload" onclick="recordEvent('Unload')">荷下ろし</button>
+      <button id="btnFuel" onclick="recordFuelEvent()">給油</button>
+      <button id="btnBreak" onclick="recordEvent('Break')">休憩</button>
+      <button id="btnRest" onclick="recordEvent('Rest')">休息</button>
     </nav>
     <main id="content">
       <!-- dynamic content -->

--- a/main.js
+++ b/main.js
@@ -1,56 +1,107 @@
-﻿// main.js - 運行管理アプリ（日本語UI）
+// main.js - 運行管理アプリ（日本語UI）
 
 // 走行ログ
 let logs = [];
 // メンテナンス記録
 let maintenance = [];
+const maintenanceIntervals = {
+  'オイル交換': 3,
+  'タイヤ交換': 24,
+  '点検': 6,
+  '車検': 24,
+  'バッテリー交換': 36,
+  'ワイパー交換': 12
+};
 
 // ワンタップ開始/終了の状態
 let currentTripStartTime = null;
 let currentTripEvents = [];
+let currentTripStartAddress = '';
 
 function toggleTrip() {
   const btn = document.getElementById('toggleTripBtn');
   if (!currentTripStartTime) {
     currentTripStartTime = new Date();
+    currentTripStartAddress = '';
+    const startTimeStr = currentTripStartTime.toTimeString().slice(0, 5);
     const label = document.getElementById('toggleLabel');
     if (label) label.textContent = '運行終了';
     if (btn) {
       btn.classList.remove('start');
       btn.classList.add('stop');
     }
+    function finalizeStart(addr) {
+      currentTripStartAddress = addr || '';
+      currentTripEvents.push({ type: '運航開始', time: startTimeStr, location: currentTripStartAddress, fuelAmount: '', fuelPrice: '' });
+    }
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const lat = pos.coords.latitude;
+          const lon = pos.coords.longitude;
+          fetch(`https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lon}`)
+            .then((r) => r.json())
+            .then((d) => finalizeStart(d.display_name))
+            .catch(() => finalizeStart(''));
+        },
+        () => finalizeStart('')
+      );
+    } else {
+      finalizeStart('');
+    }
   } else {
     const endTime = new Date();
     const startDate = currentTripStartTime;
-    const date = startDate.toISOString().slice(0, 10);
+    const startDateStr = startDate.toISOString().slice(0, 10);
     const startTimeStr = startDate.toTimeString().slice(0, 5);
+    const endDateStr = endTime.toISOString().slice(0, 10);
     const endTimeStr = endTime.toTimeString().slice(0, 5);
     const finalOdoStr = prompt('最終オドメーター（任意）:');
     const finalOdo = finalOdoStr ? finalOdoStr.trim() : '';
-    const logEntry = {
-      date,
-      startTime: startTimeStr,
-      endTime: endTimeStr,
-      purpose: '',
-      start: '',
-      end: '',
-      distance: '',
-      cost: '',
-      notes: '',
-      events: currentTripEvents.slice(),
-      finalOdo
-    };
-    logs.push(logEntry);
-    saveLogs();
-    currentTripStartTime = null;
-    currentTripEvents = [];
-    const label = document.getElementById('toggleLabel');
-    if (label) label.textContent = '運行開始';
-    if (btn) {
-      btn.classList.remove('stop');
-      btn.classList.add('start');
+    function finalizeEnd(addr) {
+      const endAddr = addr || '';
+      currentTripEvents.push({ type: '運航終了', time: endTimeStr, location: endAddr, fuelAmount: '', fuelPrice: '' });
+      const logEntry = {
+        startDate: startDateStr,
+        startTime: startTimeStr,
+        endDate: endDateStr,
+        endTime: endTimeStr,
+        purpose: '',
+        start: currentTripStartAddress,
+        end: endAddr,
+        distance: '',
+        cost: '',
+        notes: '',
+        events: currentTripEvents.slice(),
+        finalOdo
+      };
+      logs.push(logEntry);
+      saveLogs();
+      currentTripStartTime = null;
+      currentTripEvents = [];
+      const label = document.getElementById('toggleLabel');
+      if (label) label.textContent = '運行開始';
+      if (btn) {
+        btn.classList.remove('stop');
+        btn.classList.add('start');
+      }
+      showList();
     }
-    showList();
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const lat = pos.coords.latitude;
+          const lon = pos.coords.longitude;
+          fetch(`https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lon}`)
+            .then((r) => r.json())
+            .then((d) => finalizeEnd(d.display_name))
+            .catch(() => finalizeEnd(''));
+        },
+        () => finalizeEnd('')
+      );
+    } else {
+      finalizeEnd('');
+    }
   }
 }
 
@@ -59,6 +110,20 @@ function loadLogs() {
   try {
     const data = localStorage.getItem('runlog_logs');
     logs = data ? JSON.parse(data) : [];
+    logs = logs.map((l) => ({
+      startDate: l.startDate || l.date || '',
+      startTime: l.startTime || '',
+      endDate: l.endDate || l.date || '',
+      endTime: l.endTime || '',
+      purpose: l.purpose || '',
+      start: l.start || '',
+      end: l.end || '',
+      distance: l.distance || '',
+      cost: l.cost || '',
+      notes: l.notes || '',
+      events: l.events || [],
+      finalOdo: l.finalOdo || ''
+    }));
   } catch (e) {
     console.error('Failed to parse stored logs', e);
     logs = [];
@@ -82,11 +147,41 @@ function saveMaintenance() {
   localStorage.setItem('runlog_maintenance', JSON.stringify(maintenance));
 }
 
+function getNextMaintenanceDates() {
+  const latest = {};
+  maintenance.forEach((m) => {
+    if (!latest[m.type] || new Date(latest[m.type]) < new Date(m.date)) {
+      latest[m.type] = m.date;
+    }
+  });
+  const result = {};
+  Object.keys(maintenanceIntervals).forEach((type) => {
+    const last = latest[type];
+    if (last) {
+      const d = new Date(last);
+      d.setMonth(d.getMonth() + maintenanceIntervals[type]);
+      result[type] = d.toISOString().slice(0, 10);
+    } else {
+      result[type] = '未記録';
+    }
+  });
+  return result;
+}
+
+function maintenanceRecommendationsHTML() {
+  const next = getNextMaintenanceDates();
+  const items = Object.entries(next)
+    .map(([type, date]) => `<li>${type}: ${date}</li>`)
+    .join('');
+  return `<h3>次回メンテナンス目安</h3><ul>${items}</ul>`;
+}
+
 // 走行ログ フォーム
 function showForm(editIndex = -1) {
   const init = {
-    date: '',
+    startDate: '',
     startTime: '',
+    endDate: '',
     endTime: '',
     purpose: '',
     start: '',
@@ -99,46 +194,51 @@ function showForm(editIndex = -1) {
   if (editIndex >= 0) {
     log = { ...logs[editIndex] };
   } else {
-    log.date = new Date().toISOString().slice(0, 10);
+    log.startDate = new Date().toISOString().slice(0, 10);
+    log.endDate = log.startDate;
   }
   const html = `
     <h2>${editIndex >= 0 ? '記録を編集' : '新規記録'}</h2>
     <form id="logForm">
       <div>
-        <label for="date">日付:</label>
-        <input type="date" id="date" name="date" value="${log.date}">
+        <label for="startDate">開始日:</label>
+        <input type="date" id="startDate" value="${log.startDate}">
       </div>
       <div>
         <label for="startTime">開始時刻:</label>
-        <input type="time" id="startTime" name="startTime" value="${log.startTime || ''}">
+        <input type="time" id="startTime" value="${log.startTime || ''}">
+      </div>
+      <div>
+        <label for="endDate">終了日:</label>
+        <input type="date" id="endDate" value="${log.endDate || ''}">
       </div>
       <div>
         <label for="endTime">終了時刻:</label>
-        <input type="time" id="endTime" name="endTime" value="${log.endTime || ''}">
+        <input type="time" id="endTime" value="${log.endTime || ''}">
       </div>
       <div>
         <label for="purpose">目的:</label>
-        <input type="text" id="purpose" name="purpose" value="${log.purpose || ''}" placeholder="荷物・用途など">
+        <input type="text" id="purpose" value="${log.purpose || ''}" placeholder="荷物・用途など">
       </div>
       <div>
         <label for="start">出発地:</label>
-        <input type="text" id="start" name="start" value="${log.start || ''}">
+        <input type="text" id="start" value="${log.start || ''}">
       </div>
       <div>
         <label for="end">到着地:</label>
-        <input type="text" id="end" name="end" value="${log.end || ''}">
+        <input type="text" id="end" value="${log.end || ''}">
       </div>
       <div>
         <label for="distance">距離 (km):</label>
-        <input type="number" step="0.1" id="distance" name="distance" value="${log.distance || ''}">
+        <input type="number" step="0.1" id="distance" value="${log.distance || ''}">
       </div>
       <div>
         <label for="cost">費用 (円):</label>
-        <input type="number" step="0.1" id="cost" name="cost" value="${log.cost || ''}">
+        <input type="number" step="0.1" id="cost" value="${log.cost || ''}">
       </div>
       <div>
         <label for="notes">メモ:</label>
-        <textarea id="notes" name="notes" rows="3">${log.notes || ''}</textarea>
+        <textarea id="notes" rows="3">${log.notes || ''}</textarea>
       </div>
       <div>
         <button type="submit">${editIndex >= 0 ? '保存' : '追加'}</button>
@@ -155,8 +255,9 @@ function showForm(editIndex = -1) {
 }
 
 function submitLog(editIndex) {
-  const date = document.getElementById('date').value;
+  const startDate = document.getElementById('startDate').value;
   const startTime = document.getElementById('startTime').value;
+  const endDate = document.getElementById('endDate').value;
   const endTime = document.getElementById('endTime').value;
   const purpose = document.getElementById('purpose').value.trim();
   const start = document.getElementById('start').value.trim();
@@ -165,20 +266,24 @@ function submitLog(editIndex) {
   const cost = parseFloat(document.getElementById('cost').value);
   const notes = document.getElementById('notes').value.trim();
   const errors = [];
-  if (!date) errors.push('日付を入力してください。');
+  if (!startDate) errors.push('開始日を入力してください。');
   if (!startTime) errors.push('開始時刻を入力してください。');
+  if (!endDate) errors.push('終了日を入力してください。');
   if (!endTime) errors.push('終了時刻を入力してください。');
   if (!isNaN(distance) && distance < 0) errors.push('距離は0以上で入力してください。');
   if (!isNaN(cost) && cost < 0) errors.push('費用は0以上で入力してください。');
-  if (startTime && endTime && startTime > endTime) errors.push('開始時刻は終了時刻より前でなければなりません。');
+  const startDateTime = new Date(`${startDate}T${startTime}`);
+  const endDateTime = new Date(`${endDate}T${endTime}`);
+  if (startDateTime > endDateTime) errors.push('開始日時は終了日時より前でなければなりません。');
   if (errors.length > 0) {
     document.getElementById('formError').innerText = errors.join('\n');
     return;
   }
   const existing = editIndex >= 0 ? logs[editIndex] : {};
   const logEntry = {
-    date,
+    startDate,
     startTime,
+    endDate,
     endTime,
     purpose,
     start,
@@ -202,8 +307,9 @@ function showList() {
   const tableRows = logs
     .map((log, index) => `
       <tr>
-        <td>${log.date}</td>
+        <td>${log.startDate}</td>
         <td>${log.startTime}</td>
+        <td>${log.endDate}</td>
         <td>${log.endTime}</td>
         <td>${log.purpose}</td>
         <td>${log.start}</td>
@@ -222,9 +328,10 @@ function showList() {
     <table>
       <thead>
         <tr>
-          <th>日付</th>
-          <th>開始</th>
-          <th>終了</th>
+          <th>開始日</th>
+          <th>開始時刻</th>
+          <th>終了日</th>
+          <th>終了時刻</th>
           <th>目的</th>
           <th>出発地</th>
           <th>到着地</th>
@@ -269,6 +376,34 @@ function showSummary() {
   document.getElementById('content').innerHTML = html;
 }
 
+function showDailyReport() {
+  if (logs.length === 0) {
+    document.getElementById('content').innerHTML = '<p>記録がありません。</p>';
+    return;
+  }
+  const sections = logs
+    .map((log) => {
+      const events = (log.events || [])
+        .map((ev) => {
+          let s = `${ev.time} ${ev.type}`;
+          if (ev.location) s += `(${ev.location})`;
+          return `<li>${s}</li>`;
+        })
+        .join('');
+      return `
+        <section class="report">
+          <h3>${log.startDate} ${log.startTime} ～ ${log.endDate} ${log.endTime}</h3>
+          <p>出発地: ${log.start || ''}</p>
+          <p>到着地: ${log.end || ''}</p>
+          <p>目的: ${log.purpose || ''}</p>
+          <ul>${events}</ul>
+        </section>
+      `;
+    })
+    .join('');
+  document.getElementById('content').innerHTML = `<h2>日報</h2>${sections}`;
+}
+
 function recordEvent(type) {
   if (!currentTripStartTime) {
     alert('運行を開始してからイベントを記録してください。');
@@ -283,8 +418,8 @@ function recordEvent(type) {
     fuelPrice: ''
   };
   function finalize() {
-    // UIボタンは英語（Load/Unload/Break）から呼ばれる可能性があるので日本語ラベルに変換
-    const map = { 'Load': '荷積み', 'Unload': '荷卸し', 'Break': '休憩' };
+    // UIボタンは英語で呼ばれる可能性があるので日本語ラベルに変換
+    const map = { 'Load': '積み込み', 'Unload': '荷下ろし', 'Break': '休憩', 'Rest': '休息' };
     eventObj.type = map[type] || type;
     currentTripEvents.push(eventObj);
     alert(`${eventObj.type} を記録しました。`);
@@ -361,12 +496,17 @@ function recordFuelEvent() {
   }
 }
 
+function csvEscape(value) {
+  const s = value === null || value === undefined ? '' : String(value);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
 function exportCSV() {
   if (logs.length === 0) {
     alert('エクスポートする記録がありません。');
     return;
   }
-  const headers = ['日付','開始','終了','目的','出発地','到着地','距離(km)','費用(円)','メモ','イベント','最終オドメーター'];
+  const headers = ['開始日','開始時刻','終了日','終了時刻','目的','出発地','到着地','距離(km)','費用(円)','メモ','イベント','最終オドメーター'];
   const rows = logs.map((log) => {
     let eventsStr = '';
     if (log.events && log.events.length) {
@@ -385,20 +525,21 @@ function exportCSV() {
         .join('; ');
     }
     return [
-      log.date,
-      log.startTime,
-      log.endTime,
-      log.purpose,
-      log.start,
-      log.end,
-      log.distance,
-      log.cost,
-      String(log.notes || '').replace(/\n/g, '\\n'),
-      eventsStr,
-      log.finalOdo || ''
+      csvEscape(log.startDate),
+      csvEscape(log.startTime),
+      csvEscape(log.endDate),
+      csvEscape(log.endTime),
+      csvEscape(log.purpose),
+      csvEscape(log.start),
+      csvEscape(log.end),
+      csvEscape(log.distance),
+      csvEscape(log.cost),
+      csvEscape(log.notes || ''),
+      csvEscape(eventsStr),
+      csvEscape(log.finalOdo || '')
     ].join(',');
   });
-  const csvContent = [headers.join(','), ...rows].join('\n');
+  const csvContent = [headers.join(','), ...rows].join('\r\n');
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -455,6 +596,7 @@ function showMaintenanceList() {
       </thead>
       <tbody>${rows}</tbody>
     </table>
+    ${maintenanceRecommendationsHTML()}
   `;
   document.getElementById('content').innerHTML = html;
 }
@@ -544,13 +686,13 @@ function exportMaintenanceCSV() {
   }
   const headers = ['日付','内容','オドメーター','費用(円)','メモ'];
   const rows = maintenance.map((m) => [
-    m.date,
-    m.type,
-    m.odometer,
-    m.cost,
-    String(m.notes || '').replace(/\n/g, '\\n')
+    csvEscape(m.date),
+    csvEscape(m.type),
+    csvEscape(m.odometer),
+    csvEscape(m.cost),
+    csvEscape(m.notes || '')
   ].join(','));
-  const csvContent = [headers.join(','), ...rows].join('\n');
+  const csvContent = [headers.join(','), ...rows].join('\r\n');
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -583,18 +725,20 @@ window.addEventListener('load', () => {
 
 // 画面の固定ラベル（ナビ等）を日本語に
 function applyJapaneseLabels() {
-  document.title = '運行管理アプリ';
+  document.title = 'ギャラクシーズホールド運行管理';
   const h1 = document.querySelector('header h1');
-  if (h1) h1.textContent = '運行管理アプリ';
+  if (h1) h1.textContent = 'ギャラクシーズホールド運行管理';
   const setText = (id, text) => { const el = document.getElementById(id); if (el) el.textContent = text; };
   setText('toggleLabel', '運行開始');
   setText('btnNewLog', '新規記録');
   setText('btnList', '一覧');
   setText('btnSummary', '集計');
+  setText('btnDaily', '日報');
   setText('btnExport', 'CSV出力');
-  setText('btnMaintenance', 'メンテナンス');
-  setText('btnLoad', '荷積み');
-  setText('btnUnload', '荷卸し');
+  setText('btnMaintenance', '整備記録');
+  setText('btnLoad', '積み込み');
+  setText('btnUnload', '荷下ろし');
   setText('btnFuel', '給油');
   setText('btnBreak', '休憩');
+  setText('btnRest', '休息');
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "運行管理アプリ",
-  "short_name": "運行管理",
-  "description": "個人用日報・運行管理アプリ",
+  "name": "ギャラクシーズホールド運行管理",
+  "short_name": "ギャラクシー運行",
+  "description": "ギャラクシーズホールド向け運行管理アプリ",
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#0066cc",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "runlog-app",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+
+function csvEscape(value) {
+  const s = value === null || value === undefined ? '' : String(value);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+assert.equal(csvEscape('simple'), 'simple');
+assert.equal(csvEscape('a,b'), '"a,b"');
+assert.equal(csvEscape('with "quote"'), '"with ""quote"""');
+assert.equal(csvEscape('line1\nline2'), '"line1\nline2"');
+
+console.log('csvEscape tests passed');


### PR DESCRIPTION
## Summary
- translate UI and manifest for GyalaxyzHold
- auto-log start/end locations with rest events, daily report, and maintenance reminders
- quote/escape CSV export values and add unit tests

## Testing
- `node --check main.js`
- `node --check main.esc.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2e093f158832e8bd77bf8b7af5ab5