### PR TITLE
Add event end buttons with duration tracking

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-﻿const cacheName = 'runlog-cache-v5';
+﻿const cacheName = 'runlog-cache-v6';
 const assetsToCache = [
   '.',
   'index.html',
@@ -29,9 +29,9 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   event.respondWith(
-    caches.match(event.request).then((response) => {
-      return response || fetch(event.request);
-    })
+    fetch(event.request, { cache: 'no-store' })
+      .then((response) => response)
+      .catch(() => caches.match(event.request))
   );
 });
 


### PR DESCRIPTION
## Summary
- show a dedicated 終了 button for each event and track elapsed time until it's pressed
- display recorded durations within event listings
- fetch fresh assets on each request to avoid stale caches
- convert event start buttons into 終了 buttons after activation for seamless toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2e3c3f0832eaa70945fb1404543