### PR TITLE
Add date-based log view and map navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       <button id="btnNewLog" onclick="showForm()">新規記録</button>
       <button id="btnList" onclick="showList()">一覧</button>
       <button id="btnSummary" onclick="showSummary()">集計</button>
+      <button id="btnByDate" onclick="showRecordsByDate()">日付別</button>
       <button id="btnDaily" onclick="showDailyReport()">日報</button>
       <button id="btnExport" onclick="exportCSV()">CSV出力</button>
       <button id="btnMaintenance" onclick="showMaintenanceList()">整備記録</button>


### PR DESCRIPTION
## Summary
- Show daily reports in a table including fuel amounts and map links
- Add page to filter driving logs by date with Google Maps buttons
- Display fuel volume in event listings and navigation button for addresses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e9128514832e91a58c36bd2c47ee