### PR TITLE
feat: show PWA install button

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       <button id="btnFuel" onclick="recordFuelEvent()">給油</button>
       <button id="btnBreak" onclick="recordEvent('Break')">休憩</button>
       <button id="btnRest" onclick="recordEvent('Rest')">休息</button>
-      <button id="btnInstall" class="hidden">インストール</button>
+      <button id="btnInstall" disabled>インストール</button>
     </nav>
     <main id="content">
       <!-- dynamic content -->

--- a/main.esc.js
+++ b/main.esc.js
@@ -995,24 +995,35 @@ window.addEventListener('beforeinstallprompt', (e) => {
   e.preventDefault();
   deferredInstallPrompt = e;
   const btn = document.getElementById('btnInstall');
-  if (btn) btn.classList.remove('hidden');
+  if (btn) {
+    btn.disabled = false;
+    btn.classList.remove('hidden');
+  }
 });
 
 function setupInstallButton() {
   const btn = document.getElementById('btnInstall');
   if (!btn) return;
+  btn.disabled = true;
   btn.addEventListener('click', async () => {
-    if (!deferredInstallPrompt) return;
+    if (!deferredInstallPrompt) {
+      alert('インストールは現在利用できません。ブラウザのメニューから追加してください。');
+      return;
+    }
     deferredInstallPrompt.prompt();
     await deferredInstallPrompt.userChoice;
     deferredInstallPrompt = null;
+    btn.disabled = true;
     btn.classList.add('hidden');
   });
 }
 
 window.addEventListener('appinstalled', () => {
   const btn = document.getElementById('btnInstall');
-  if (btn) btn.classList.add('hidden');
+  if (btn) {
+    btn.disabled = true;
+    btn.classList.add('hidden');
+  }
 });
 
 // 起動時処理

--- a/main.js
+++ b/main.js
@@ -995,24 +995,35 @@ window.addEventListener('beforeinstallprompt', (e) => {
   e.preventDefault();
   deferredInstallPrompt = e;
   const btn = document.getElementById('btnInstall');
-  if (btn) btn.classList.remove('hidden');
+  if (btn) {
+    btn.disabled = false;
+    btn.classList.remove('hidden');
+  }
 });
 
 function setupInstallButton() {
   const btn = document.getElementById('btnInstall');
   if (!btn) return;
+  btn.disabled = true;
   btn.addEventListener('click', async () => {
-    if (!deferredInstallPrompt) return;
+    if (!deferredInstallPrompt) {
+      alert('インストールは現在利用できません。ブラウザのメニューから追加してください。');
+      return;
+    }
     deferredInstallPrompt.prompt();
     await deferredInstallPrompt.userChoice;
     deferredInstallPrompt = null;
+    btn.disabled = true;
     btn.classList.add('hidden');
   });
 }
 
 window.addEventListener('appinstalled', () => {
   const btn = document.getElementById('btnInstall');
-  if (btn) btn.classList.add('hidden');
+  if (btn) {
+    btn.disabled = true;
+    btn.classList.add('hidden');
+  }
 });
 
 // 起動時処理


### PR DESCRIPTION
## Summary
- Display install button by default and enable it once installation prompt is available
- Alert users when installation isn't available and hide button after install

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f45a3d00832e9d50335faed8311a