### PR TITLE
Add foldable detection and rename app

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ギャラクシーズホールド運行管理</title>
+  <title>運行管理(K)</title>
   <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="styles.css">
   <script src="main.esc.js" defer></script>
@@ -11,7 +11,7 @@
 </head>
 <body>
   <header>
-    <h1>ギャラクシーズホールド運行管理</h1>
+    <h1>運行管理(K)</h1>
   </header>
   <div class="layout">
     <nav>

--- a/main.esc.js
+++ b/main.esc.js
@@ -31,6 +31,14 @@ const eventButtonMap = {
 const geoOptions = { enableHighAccuracy: false, maximumAge: 600000, timeout: 5000 };
 let deferredInstallPrompt = null;
 
+function applyDeviceClass() {
+  const ua = navigator.userAgent.toLowerCase();
+  const isFold = ua.includes('z fold') || ua.includes('sm-f96') || ua.includes('sm-f97') || (ua.includes('samsung') && ua.includes('fold'));
+  const body = document.body;
+  if (!body) return;
+  body.classList.add(isFold ? 'fold' : 'android');
+}
+
 function updateEventButton(jpType, ongoing) {
   const map = eventButtonMap[jpType];
   if (!map) return;
@@ -1020,6 +1028,7 @@ window.addEventListener('load', () => {
   loadLogs();
   loadMaintenance();
   applyJapaneseLabels();
+  applyDeviceClass();
   showList();
   registerServiceWorker();
   setupInstallButton();
@@ -1027,9 +1036,9 @@ window.addEventListener('load', () => {
 
 // 画面の固定ラベル（ナビ等）を日本語に
 function applyJapaneseLabels() {
-  document.title = 'ギャラクシーズホールド運行管理';
+  document.title = '運行管理(K)';
   const h1 = document.querySelector('header h1');
-  if (h1) h1.textContent = 'ギャラクシーズホールド運行管理';
+  if (h1) h1.textContent = '運行管理(K)';
   const setText = (id, text) => { const el = document.getElementById(id); if (el) el.textContent = text; };
   setText('toggleLabel', '運行開始');
   setText('btnNewLog', '新規記録');

--- a/main.js
+++ b/main.js
@@ -31,6 +31,14 @@ const eventButtonMap = {
 const geoOptions = { enableHighAccuracy: false, maximumAge: 600000, timeout: 5000 };
 let deferredInstallPrompt = null;
 
+function applyDeviceClass() {
+  const ua = navigator.userAgent.toLowerCase();
+  const isFold = ua.includes('z fold') || ua.includes('sm-f96') || ua.includes('sm-f97') || (ua.includes('samsung') && ua.includes('fold'));
+  const body = document.body;
+  if (!body) return;
+  body.classList.add(isFold ? 'fold' : 'android');
+}
+
 function updateEventButton(jpType, ongoing) {
   const map = eventButtonMap[jpType];
   if (!map) return;
@@ -1020,6 +1028,7 @@ window.addEventListener('load', () => {
   loadLogs();
   loadMaintenance();
   applyJapaneseLabels();
+  applyDeviceClass();
   showList();
   registerServiceWorker();
   setupInstallButton();
@@ -1027,9 +1036,9 @@ window.addEventListener('load', () => {
 
 // 画面の固定ラベル（ナビ等）を日本語に
 function applyJapaneseLabels() {
-  document.title = 'ギャラクシーズホールド運行管理';
+  document.title = '運行管理(K)';
   const h1 = document.querySelector('header h1');
-  if (h1) h1.textContent = 'ギャラクシーズホールド運行管理';
+  if (h1) h1.textContent = '運行管理(K)';
   const setText = (id, text) => { const el = document.getElementById(id); if (el) el.textContent = text; };
   setText('toggleLabel', '運行開始');
   setText('btnNewLog', '新規記録');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "ギャラクシーズホールド運行管理",
-  "short_name": "ギャラクシー運行",
-  "description": "ギャラクシーズホールド向け運行管理アプリ",
+  "name": "運行管理(K)",
+  "short_name": "運行管理(K)",
+  "description": "折り畳み端末や通常Androidに最適化された運行管理アプリ",
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#0066cc",

--- a/styles.css
+++ b/styles.css
@@ -132,6 +132,31 @@ main {
   }
 }
 
+/* Layout adjustments for detected foldable devices */
+body.fold .layout {
+  flex-direction: row;
+  min-height: calc(100vh - 60px);
+}
+
+body.fold nav {
+  flex-direction: column;
+  align-items: stretch;
+  width: 220px;
+  height: 100%;
+  padding: 1rem;
+}
+
+body.fold nav button {
+  width: 100%;
+  margin-bottom: 0.8rem;
+  justify-content: flex-start;
+}
+
+body.fold main {
+  flex: 1;
+  padding: 1.5rem 2rem;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- rename app to 運行管理(K) across HTML and manifest
- detect Galaxy Z Fold devices and apply fold-friendly layout
- add fold-specific CSS to optimize navigation on foldable screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f57810f8832ea9ac8d45b9139182