### PR TITLE
Ensure PWA install button is hidden until available

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       <button id="btnFuel" onclick="recordFuelEvent()">給油</button>
       <button id="btnBreak" onclick="recordEvent('Break')">休憩</button>
       <button id="btnRest" onclick="recordEvent('Rest')">休息</button>
-      <button id="btnInstall" disabled>インストール</button>
+      <button id="btnInstall" class="hidden">インストール</button>
     </nav>
     <main id="content">
       <!-- dynamic content -->


### PR DESCRIPTION
## Summary
- Hide PWA install button until the `beforeinstallprompt` event fires so the app behaves like a proper PWA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6fbea5400832e8062b6c80814fbdc