### PR TITLE
Add PWA meta tags and fullscreen display

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
   <link rel="stylesheet" href="styles.css">
   <script src="main.esc.js" defer></script>
   <meta name="theme-color" content="#0066cc">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="運行管理(K)">
+  <link rel="apple-touch-icon" href="icons/icon-192.png">
 </head>
 <body>
   <header>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "運行管理(K)",
   "description": "折り畳み端末や通常Androidに最適化された運行管理アプリ",
   "start_url": ".",
-  "display": "standalone",
+  "display": "fullscreen",
   "theme_color": "#0066cc",
   "background_color": "#ffffff",
   "icons": [


### PR DESCRIPTION
## Summary
- enable iOS fullscreen by adding apple-specific meta tags and touch icon
- hide Android status bar by setting manifest display to `fullscreen`
- add `mobile-web-app-capable` meta tag to support Android standalone mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c709a78084832e9395934ca6056d15