### PR TITLE
Fix offline handling to serve cached index

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -34,7 +34,7 @@ self.addEventListener('fetch', (event) => {
   if (event.request.mode === 'navigate') {
     event.respondWith(
       fetch(event.request, { cache: 'no-store' })
-        .catch(() => caches.match('offline.html'))
+        .catch(() => caches.match('index.html'))
     );
   } else {
     event.respondWith(


### PR DESCRIPTION
## Summary
- Serve cached `index.html` for navigation requests when offline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70d590bf0832ea0f7452dbdc9566a