### PR TITLE
Prevent accidental reload in runlog app

### DIFF
--- a/main.esc.js
+++ b/main.esc.js
@@ -31,6 +31,13 @@ const eventButtonMap = {
 const geoOptions = { enableHighAccuracy: false, maximumAge: 600000, timeout: 5000 };
 let deferredInstallPrompt = null;
 
+window.addEventListener('beforeunload', (e) => {
+  if (currentTripStartTime || currentTripEvents.length > 0) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+});
+
 function applyDeviceClass() {
   const ua = navigator.userAgent.toLowerCase();
   const isFold = ua.includes('z fold') || ua.includes('sm-f96') || ua.includes('sm-f97') || (ua.includes('samsung') && ua.includes('fold'));

--- a/main.js
+++ b/main.js
@@ -31,6 +31,13 @@ const eventButtonMap = {
 const geoOptions = { enableHighAccuracy: false, maximumAge: 600000, timeout: 5000 };
 let deferredInstallPrompt = null;
 
+window.addEventListener('beforeunload', (e) => {
+  if (currentTripStartTime || currentTripEvents.length > 0) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+});
+
 function applyDeviceClass() {
   const ua = navigator.userAgent.toLowerCase();
   const isFold = ua.includes('z fold') || ua.includes('sm-f96') || ua.includes('sm-f97') || (ua.includes('samsung') && ua.includes('fold'));

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+html, body {
+  overscroll-behavior-y: contain;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;


### PR DESCRIPTION
## Summary
- warn before leaving the page to avoid losing in-progress trips
- disable pull-to-refresh to stop accidental reloads on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8197045c4832ebf64ac8f574186bb