### PR TITLE
Improve CSV export formatting and add sheet upload option

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       <button id="btnByDate" onclick="showRecordsByDate()">日付別</button>
       <button id="btnDaily" onclick="showDailyReport()">日報</button>
       <button id="btnExport" onclick="exportCSV()">CSV出力</button>
+      <button id="btnExportSheet" onclick="exportToSheet()">シート送信</button>
       <button id="btnMaintenance" onclick="showMaintenanceList()">整備記録</button>
 
       <button id="btnLoad" onclick="recordEvent('Load')">積み込み</button>


### PR DESCRIPTION
## Summary
- format CSV export with newline-separated events and BOM for better spreadsheet parsing
- add ability to send logs to a Google Sheet via stored script URL
- expose "シート送信" button in navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c82f5d9118832eb3454cb742ede753