### PR TITLE
Add cargo description to loading events and clean navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
       <button id="toggleTripBtn" class="start" onclick="toggleTrip()">
         <span id="toggleLabel">運行開始</span>
       </button>
-      <button id="btnNewLog" onclick="showForm()">新規記録</button>
       <button id="btnList" onclick="showList()">一覧</button>
       <button id="btnSummary" onclick="showSummary()">集計</button>
       <button id="btnByDate" onclick="showRecordsByDate()">日付別</button>


### PR DESCRIPTION
## Summary
- prompt for cargo details when starting a loading event and store the note with the event
- surface the recorded cargo information throughout event displays and exports
- remove the unused "新規記録" navigation button from the sidebar

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cac88d9430832e89213a22dc3cc3ea