### PR TITLE
Add trip day counter to running trips

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       <button id="toggleTripBtn" class="start" onclick="toggleTrip()">
         <span id="toggleLabel">運行開始</span>
       </button>
+      <div id="tripDayCounter" class="trip-day hidden" aria-live="polite"></div>
       <div id="statusIndicator" class="status-indicator status-inactive" aria-live="polite">停止中</div>
       <button id="btnList" onclick="showList()">一覧</button>
       <button id="btnSummary" onclick="showSummary()">集計</button>

--- a/main.js
+++ b/main.js
@@ -248,6 +248,7 @@ let currentTripStartAddress = '';
 let currentTripStartLat = null;
 let currentTripStartLon = null;
 let currentTripStartOdo = '';
+let tripDayIntervalId = null;
 
 const DRIVING_EVENT_TYPE = '走行中';
 
@@ -316,7 +317,6 @@ function stopDrivingSegment(timestamp = Date.now()) {
 
 function updateCurrentStatusDisplay() {
   const indicator = document.getElementById('statusIndicator');
-  if (!indicator) return;
   let label = '停止中';
   let statusClass = 'status-inactive';
   if (currentTripStartTime) {
@@ -332,9 +332,76 @@ function updateCurrentStatusDisplay() {
       statusClass = 'status-driving';
     }
   }
-  indicator.textContent = label;
-  indicator.classList.remove('status-inactive', 'status-driving', 'status-task');
-  indicator.classList.add(statusClass);
+  if (indicator) {
+    indicator.textContent = label;
+    indicator.classList.remove('status-inactive', 'status-driving', 'status-task');
+    indicator.classList.add(statusClass);
+  }
+  updateTripDayDisplay();
+}
+
+function calculateTripDayNumber(startDate, referenceDate = new Date()) {
+  if (!(startDate instanceof Date)) return null;
+  const startTime = startDate.getTime();
+  if (Number.isNaN(startTime)) return null;
+  const reference = referenceDate instanceof Date ? referenceDate : new Date(referenceDate);
+  if (!(reference instanceof Date) || Number.isNaN(reference.getTime())) return null;
+  const startDay = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const referenceDay = new Date(reference.getFullYear(), reference.getMonth(), reference.getDate());
+  const diffDays = Math.floor((referenceDay - startDay) / DAY_MS);
+  if (Number.isNaN(diffDays)) return null;
+  return diffDays >= 0 ? diffDays + 1 : 1;
+}
+
+function updateTripDayDisplay() {
+  const element = document.getElementById('tripDayCounter');
+  if (!element) return;
+  if (!currentTripStartTime) {
+    element.innerHTML = '';
+    element.classList.add('hidden');
+    element.removeAttribute('aria-label');
+    return;
+  }
+  const dayNumber = calculateTripDayNumber(currentTripStartTime);
+  if (!dayNumber) {
+    element.innerHTML = '';
+    element.classList.add('hidden');
+    element.removeAttribute('aria-label');
+    return;
+  }
+  const mainLabel = `運行${dayNumber}日目`;
+  const startDateLabel = dateToLocalDateString(currentTripStartTime);
+  const subLabel = startDateLabel ? `開始: ${startDateLabel}` : '';
+  const subHtml = subLabel ? `<span class="trip-day__sub">${subLabel}</span>` : '';
+  element.innerHTML = `<span class="trip-day__main">${mainLabel}</span>${subHtml}`;
+  element.classList.remove('hidden');
+  if (subLabel) {
+    element.setAttribute('aria-label', `${mainLabel}（${subLabel}）`);
+  } else {
+    element.setAttribute('aria-label', mainLabel);
+  }
+}
+
+function startTripDayTicker() {
+  if (!currentTripStartTime) {
+    stopTripDayTicker();
+    return;
+  }
+  if (tripDayIntervalId !== null) {
+    clearInterval(tripDayIntervalId);
+  }
+  updateTripDayDisplay();
+  tripDayIntervalId = window.setInterval(() => {
+    updateTripDayDisplay();
+  }, 60000);
+}
+
+function stopTripDayTicker() {
+  if (tripDayIntervalId !== null) {
+    clearInterval(tripDayIntervalId);
+    tripDayIntervalId = null;
+  }
+  updateTripDayDisplay();
 }
 
 const geoOptions = { enableHighAccuracy: false, maximumAge: 600000, timeout: 5000 };
@@ -536,6 +603,7 @@ function toggleTrip() {
     currentTripStartAddress = '';
     currentTripStartOdo = '';
     currentTripEvents = [];
+    startTripDayTicker();
     updateCurrentStatusDisplay();
     const startOdoStr = prompt('開始オドメーター（任意）:');
     currentTripStartOdo = startOdoStr ? startOdoStr.trim() : '';
@@ -642,6 +710,7 @@ function toggleTrip() {
       currentTripStartOdo = '';
       currentTripStartLat = null;
       currentTripStartLon = null;
+      stopTripDayTicker();
       updateCurrentStatusDisplay();
       clearCurrentTripState();
       const label = document.getElementById('toggleLabel');
@@ -2344,6 +2413,11 @@ window.addEventListener('load', () => {
   applyDeviceClass();
   updateTripButtonUI();
   restoreEventButtonStates();
+  if (currentTripStartTime) {
+    startTripDayTicker();
+  } else {
+    updateTripDayDisplay();
+  }
   showList();
   registerServiceWorker();
   setupInstallButton();

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,33 @@ nav .status-indicator {
   box-sizing: border-box;
 }
 
+nav .trip-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.15rem;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  border-radius: 4px;
+  background: #fff;
+  color: #0f3d75;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+  min-width: 8.5rem;
+  box-sizing: border-box;
+}
+
+.trip-day__main {
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.trip-day__sub {
+  font-size: 0.75rem;
+  color: #475569;
+  letter-spacing: 0.03em;
+}
+
 .status-indicator.status-inactive {
   background: #f1f5f9;
   color: #475569;


### PR DESCRIPTION
## Summary
- add a "運行◯日目" counter beside the status indicator so multi-day trips show their progress
- update the main scripts to maintain the day counter, persist across reloads, and stop when the trip ends

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cad3917290832eb372272fbc5b03bc