### PR TITLE
Show recorded address when location pending

### DIFF
--- a/main.esc.js
+++ b/main.esc.js
@@ -1852,7 +1852,7 @@ function formatLocation(address, lat, lon, options = {}) {
     const link = renderLocationLink(lat, lon, { label: linkLabel });
     if (link) segments.push(link);
   }
-  if (pending && showPendingLabel) {
+  if (pending && showPendingLabel && !displayValue) {
     segments.push('<span class="location-status">住所取得中…</span>');
   }
   if (segments.length === 0) {

--- a/main.js
+++ b/main.js
@@ -1953,7 +1953,7 @@ function formatLocation(address, lat, lon, options = {}) {
     const link = renderLocationLink(lat, lon, { label: linkLabel });
     if (link) segments.push(link);
   }
-  if (pending && showPendingLabel) {
+  if (pending && showPendingLabel && !displayValue) {
     segments.push('<span class="location-status">住所取得中…</span>');
   }
   if (segments.length === 0) {


### PR DESCRIPTION
## Summary
- stop showing the pending address indicator when a formatted address is already available
- apply the same pending-label condition to the shipped script bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd68a4c950832eb00f22c3c31377b6