### PR TITLE
Display navigation destination next to map links

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -375,6 +375,27 @@ h2 {
   text-decoration: underline;
 }
 
+.location-nav-target {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-left: 0.3rem;
+  font-size: 0.8rem;
+  color: #475569;
+  min-width: 0;
+}
+
+.location-nav-label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.location-nav-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .location-status {
   font-size: 0.8rem;
   color: #b45309;


### PR DESCRIPTION
## Summary
- show the full navigation destination next to map links by enhancing the location formatter and enabling the feature for log/event cards in list and date views
- add styles so the new "ナビ先" indicator remains readable, even for long addresses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cf82be403c832e84477321d08e2599