### PR TITLE
Adjust navigation target address display

### DIFF
--- a/main.esc.js
+++ b/main.esc.js
@@ -1903,19 +1903,19 @@ function formatLocation(address, lat, lon, options = {}) {
   }
   let navTarget = '';
   if (showNavigationTarget) {
-    let candidate = '';
-    if (navigationAddress !== undefined && navigationAddress !== null) {
-      candidate = navigationAddress;
-    } else if (displayOverride) {
-      candidate = displayOverride;
-    } else if (normalized) {
-      candidate = normalized;
-    }
-    const normalizedCandidate = normalizeDisplayAddress(candidate);
-    if (normalizedCandidate) {
-      navTarget = normalizedCandidate;
-    } else if (isValidCoordinate(lat) && isValidCoordinate(lon)) {
-      navTarget = `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+    const navCandidates = [
+      navigationAddress,
+      displayOverride,
+      normalized,
+      summary !== displayValue ? displayValue : '',
+      address
+    ];
+    for (const candidate of navCandidates) {
+      const normalizedCandidate = normalizeDisplayAddress(candidate);
+      if (normalizedCandidate) {
+        navTarget = normalizedCandidate;
+        break;
+      }
     }
   }
   let showNavTargetSegment = false;

--- a/main.js
+++ b/main.js
@@ -2004,19 +2004,19 @@ function formatLocation(address, lat, lon, options = {}) {
   }
   let navTarget = '';
   if (showNavigationTarget) {
-    let candidate = '';
-    if (navigationAddress !== undefined && navigationAddress !== null) {
-      candidate = navigationAddress;
-    } else if (displayOverride) {
-      candidate = displayOverride;
-    } else if (normalized) {
-      candidate = normalized;
-    }
-    const normalizedCandidate = normalizeDisplayAddress(candidate);
-    if (normalizedCandidate) {
-      navTarget = normalizedCandidate;
-    } else if (isValidCoordinate(lat) && isValidCoordinate(lon)) {
-      navTarget = `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+    const navCandidates = [
+      navigationAddress,
+      displayOverride,
+      normalized,
+      summary !== displayValue ? displayValue : '',
+      address
+    ];
+    for (const candidate of navCandidates) {
+      const normalizedCandidate = normalizeDisplayAddress(candidate);
+      if (normalizedCandidate) {
+        navTarget = normalizedCandidate;
+        break;
+      }
     }
   }
   let showNavTargetSegment = false;


### PR DESCRIPTION
## Summary
- prefer textual address data when rendering the navigation target label in list views
- remove the fallback that showed raw latitude/longitude values in the navigation target slot
- keep the map link while surfacing full address text for long entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf92126064832e8a0882e696b66e56