### PR TITLE
feat: add offline splash and route tracking history

### DIFF
--- a/app-enhancements.js
+++ b/app-enhancements.js
@@ -1,0 +1,1374 @@
+/* global document, window, navigator, localStorage, CustomEvent */
+(function initEnhancements() {
+  'use strict';
+
+  const SPLASH_TIMEOUT_MS = 5000;
+  const ROUTE_STORAGE_KEY = 'runlog_routes_v1';
+  const ROUTE_DRAFT_KEY = 'runlog_active_route_v1';
+  const ROUTE_EDIT_DRAFT_KEY = 'runlog_route_edit_drafts_v1';
+  const ROUTE_UNDO_KEY = 'runlog_route_undo_v1';
+  const CRASH_QUEUE_KEY = 'runlog_crash_queue_v1';
+  const SYNC_QUEUE_KEY = 'runlog_sync_queue_v1';
+  const MAX_NAV_WAYPOINTS = 20;
+  const MIN_SAMPLE_DISTANCE_M = 35;
+  const MIN_SAMPLE_TIME_MS = 12000;
+  const MIN_SAMPLE_ANGLE_DEG = 15;
+  const LARGE_GAP_DISTANCE_M = 500;
+  const LARGE_GAP_TIME_MS = 60000;
+
+  const appState = {
+    store: null,
+    recorder: null,
+    history: null,
+    splash: null,
+    crashReporter: null,
+  };
+
+  function safeParse(json, fallback) {
+    if (typeof json !== 'string' || !json) return fallback;
+    try {
+      return JSON.parse(json);
+    } catch (error) {
+      console.warn('Failed to parse JSON', error);
+      return fallback;
+    }
+  }
+
+  function safeStringify(value) {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      console.warn('Failed to stringify value', error);
+      return null;
+    }
+  }
+
+  function storageGet(key, fallback) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null || raw === undefined) return fallback;
+      return safeParse(raw, fallback);
+    } catch (error) {
+      console.warn('Failed to get storage', key, error);
+      return fallback;
+    }
+  }
+
+  function storageSet(key, value) {
+    try {
+      const serialized = safeStringify(value);
+      if (serialized === null) return false;
+      localStorage.setItem(key, serialized);
+      return true;
+    } catch (error) {
+      console.warn('Failed to set storage', key, error);
+      return false;
+    }
+  }
+
+  function storageRemove(key) {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.warn('Failed to remove storage', key, error);
+    }
+  }
+
+  function generateId(prefix) {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return `${prefix}_${crypto.randomUUID()}`;
+    }
+    return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  function toRad(deg) {
+    return deg * (Math.PI / 180);
+  }
+
+  function toDeg(rad) {
+    return rad * (180 / Math.PI);
+  }
+
+  function haversineDistanceMeters(lat1, lon1, lat2, lon2) {
+    const R = 6371000;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+  }
+
+  function calculateBearing(lat1, lon1, lat2, lon2) {
+    const dLon = toRad(lon2 - lon1);
+    const y = Math.sin(dLon) * Math.cos(toRad(lat2));
+    const x = Math.cos(toRad(lat1)) * Math.sin(toRad(lat2)) -
+      Math.sin(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(dLon);
+    const brng = Math.atan2(y, x);
+    return (toDeg(brng) + 360) % 360;
+  }
+
+  function formatDateTime(timestamp) {
+    if (!timestamp) return '-';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '-';
+    const datePart = date.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' });
+    const timePart = date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+    return `${datePart} ${timePart}`;
+  }
+
+  function formatDuration(ms) {
+    if (!ms || ms < 0) return '00:00:00';
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  function formatDistance(meters) {
+    if (!meters || meters <= 0) return '0 km';
+    return `${(meters / 1000).toFixed(2)} km`;
+  }
+
+  function formatDateInputValue(timestamp) {
+    if (!timestamp) return '';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toISOString().slice(0, 10);
+  }
+
+  function csvEscape(value) {
+    const s = value === null || value === undefined ? '' : String(value);
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  }
+
+  class CrashReporter {
+    constructor() {
+      this.queue = storageGet(CRASH_QUEUE_KEY, []);
+      this.isFlushing = false;
+      this.flush = this.flush.bind(this);
+      window.addEventListener('online', this.flush);
+      this.installHandlers();
+    }
+
+    installHandlers() {
+      window.addEventListener('error', (event) => {
+        const error = event?.error || new Error(String(event?.message || 'Unknown error'));
+        this.capture(error, { type: 'error', source: event?.filename || 'window' });
+      });
+      window.addEventListener('unhandledrejection', (event) => {
+        const reason = event?.reason instanceof Error ? event.reason : new Error(String(event?.reason || 'Unhandled rejection'));
+        this.capture(reason, { type: 'promise', source: 'unhandledrejection' });
+      });
+    }
+
+    capture(error, context = {}) {
+      if (!error) return;
+      const payload = {
+        id: generateId('crash'),
+        timestamp: Date.now(),
+        message: error.message || String(error),
+        stack: error.stack || null,
+        context,
+        userAgent: navigator.userAgent,
+        online: navigator.onLine,
+      };
+      this.queue.push(payload);
+      storageSet(CRASH_QUEUE_KEY, this.queue);
+      if (navigator.onLine) {
+        this.flush();
+      }
+    }
+
+    async flush() {
+      if (this.isFlushing) return;
+      if (!navigator.onLine) return;
+      if (!this.queue.length) return;
+      this.isFlushing = true;
+      try {
+        while (this.queue.length) {
+          const payload = this.queue[0];
+          const body = safeStringify(payload);
+          if (typeof body !== 'string') break;
+          let sent = false;
+          try {
+            if (navigator.sendBeacon) {
+              sent = navigator.sendBeacon('/crash-report', body);
+            }
+          } catch (err) {
+            console.warn('sendBeacon failed', err);
+          }
+          if (!sent) {
+            try {
+              const response = await fetch('/crash-report', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body,
+                keepalive: true,
+              });
+              sent = response.ok;
+            } catch (err) {
+              console.warn('Crash report upload failed', err);
+            }
+          }
+          if (!sent) break;
+          this.queue.shift();
+          storageSet(CRASH_QUEUE_KEY, this.queue);
+        }
+      } finally {
+        this.isFlushing = false;
+      }
+    }
+  }
+
+  class SplashController {
+    constructor(timeout = SPLASH_TIMEOUT_MS) {
+      this.timeout = timeout;
+      this.visible = false;
+      this.timerId = null;
+      this.el = null;
+      this.messageEl = null;
+      this.offlineBtn = null;
+      this.dismissed = false;
+    }
+
+    attach() {
+      this.el = document.getElementById('splashScreen');
+      if (!this.el) return;
+      this.messageEl = document.getElementById('splashMessage');
+      this.offlineBtn = document.getElementById('splashOfflineBtn');
+      this.show();
+      window.addEventListener('online', () => this.updateMessage());
+      window.addEventListener('offline', () => this.updateMessage());
+      document.addEventListener('runlog:ready', () => this.hide('ready'), { once: true });
+      window.addEventListener('load', () => this.hide('load'), { once: true });
+      if (this.offlineBtn) {
+        this.offlineBtn.addEventListener('click', () => this.hide('manual'));
+      }
+    }
+
+    show() {
+      if (!this.el) return;
+      this.visible = true;
+      this.dismissed = false;
+      this.el.style.display = 'flex';
+      this.el.classList.remove('hidden');
+      this.updateMessage();
+      if (this.offlineBtn) {
+        this.offlineBtn.hidden = navigator.onLine;
+      }
+      this.timerId = window.setTimeout(() => this.hide('timeout'), this.timeout);
+    }
+
+    updateMessage() {
+      if (!this.messageEl) return;
+      if (navigator.onLine) {
+        this.messageEl.textContent = '初期化中...';
+        if (this.offlineBtn) this.offlineBtn.hidden = true;
+      } else {
+        this.messageEl.textContent = 'オフラインモードで起動しています';
+        if (this.offlineBtn && !this.dismissed) this.offlineBtn.hidden = false;
+      }
+    }
+
+    hide(reason) {
+      if (!this.el || !this.visible) return;
+      this.visible = false;
+      this.dismissed = true;
+      if (this.timerId) {
+        window.clearTimeout(this.timerId);
+        this.timerId = null;
+      }
+      this.el.classList.add('hidden');
+      window.setTimeout(() => {
+        if (this.el) this.el.style.display = 'none';
+      }, 320);
+      document.dispatchEvent(new CustomEvent('runlog:splash-hidden', { detail: { reason } }));
+    }
+  }
+
+  class RouteStore {
+    constructor() {
+      this.routes = storageGet(ROUTE_STORAGE_KEY, []);
+      this.activeDraft = storageGet(ROUTE_DRAFT_KEY, null);
+      this.editDrafts = storageGet(ROUTE_EDIT_DRAFT_KEY, {});
+      this.undoHistory = storageGet(ROUTE_UNDO_KEY, {});
+      this.syncQueue = storageGet(SYNC_QUEUE_KEY, []);
+    }
+
+    getRoutes() {
+      return [...this.routes].sort((a, b) => (b.startAt || 0) - (a.startAt || 0));
+    }
+
+    upsertRoute(route) {
+      if (!route || !route.id) return;
+      const index = this.routes.findIndex((item) => item && item.id === route.id);
+      if (index >= 0) {
+        this.routes[index] = { ...route };
+      } else {
+        this.routes.push({ ...route });
+      }
+      storageSet(ROUTE_STORAGE_KEY, this.routes);
+      this.enqueueSync({ type: 'upsert', routeId: route.id });
+      this.notify({ route });
+    }
+
+    setRoutes(routes) {
+      this.routes = [...routes];
+      storageSet(ROUTE_STORAGE_KEY, this.routes);
+      this.enqueueSync({ type: 'replace', routes: this.routes.map((route) => route.id) });
+      this.notify();
+    }
+
+    removeRoute(routeId) {
+      this.setRoutes(this.routes.filter((route) => route.id !== routeId));
+      this.enqueueSync({ type: 'delete', routeId });
+    }
+
+    getActiveDraft() {
+      return this.activeDraft ? { ...this.activeDraft } : null;
+    }
+
+    saveActiveDraft(route) {
+      this.activeDraft = route ? { ...route } : null;
+      if (route) {
+        storageSet(ROUTE_DRAFT_KEY, this.activeDraft);
+      } else {
+        storageRemove(ROUTE_DRAFT_KEY);
+      }
+    }
+
+    getEditDraft(routeId) {
+      if (!routeId) return null;
+      const drafts = this.editDrafts || {};
+      return drafts[routeId] ? { ...drafts[routeId] } : null;
+    }
+
+    setEditDraft(routeId, draft) {
+      if (!routeId) return;
+      const drafts = this.editDrafts || {};
+      if (draft === null) {
+        delete drafts[routeId];
+      } else {
+        drafts[routeId] = { ...draft };
+      }
+      this.editDrafts = drafts;
+      storageSet(ROUTE_EDIT_DRAFT_KEY, drafts);
+    }
+
+    getUndoState(routeId) {
+      if (!routeId) return { undo: [], redo: [] };
+      const history = this.undoHistory || {};
+      const entry = history[routeId] || { undo: [], redo: [] };
+      entry.undo = entry.undo || [];
+      entry.redo = entry.redo || [];
+      return entry;
+    }
+
+    saveUndoState(routeId, entry) {
+      if (!routeId) return;
+      const history = this.undoHistory || {};
+      history[routeId] = {
+        undo: (entry.undo || []).slice(-20),
+        redo: (entry.redo || []).slice(-20),
+      };
+      this.undoHistory = history;
+      storageSet(ROUTE_UNDO_KEY, history);
+    }
+
+    enqueueSync(task) {
+      if (!task) return;
+      this.syncQueue = this.syncQueue || [];
+      this.syncQueue.push({ ...task, queuedAt: Date.now() });
+      storageSet(SYNC_QUEUE_KEY, this.syncQueue);
+      document.dispatchEvent(new CustomEvent('runlog:sync-queued', { detail: { queueLength: this.syncQueue.length } }));
+    }
+
+    markSynced(predicate) {
+      if (!Array.isArray(this.syncQueue) || !this.syncQueue.length) return;
+      const remaining = this.syncQueue.filter((task) => {
+        if (!predicate) return true;
+        return !predicate(task);
+      });
+      this.syncQueue = remaining;
+      storageSet(SYNC_QUEUE_KEY, remaining);
+    }
+
+    notify(detail) {
+      document.dispatchEvent(new CustomEvent('runlog:routes-changed', { detail }));
+    }
+  }
+
+  class RouteRecorder {
+    constructor(store, crashReporter) {
+      this.store = store;
+      this.crashReporter = crashReporter;
+      this.state = 'idle';
+      this.watchId = null;
+      this.activeRoute = null;
+      this.lastPoint = null;
+      this.statusEl = null;
+      this.recordBtn = null;
+      this.stopBtn = null;
+      this.waypointBtn = null;
+      this.statusInterval = null;
+      this.restored = false;
+    }
+
+    init() {
+      this.statusEl = document.getElementById('routeStatus');
+      this.recordBtn = document.getElementById('btnRouteRecord');
+      this.stopBtn = document.getElementById('btnRouteStop');
+      this.waypointBtn = document.getElementById('btnRouteWaypoint');
+      if (this.recordBtn) {
+        this.recordBtn.addEventListener('click', () => this.toggle());
+      }
+      if (this.stopBtn) {
+        this.stopBtn.addEventListener('click', () => this.stop());
+      }
+      if (this.waypointBtn) {
+        this.waypointBtn.addEventListener('click', () => this.addWaypoint());
+      }
+      window.addEventListener('online', () => this.updateStatus());
+      window.addEventListener('offline', () => this.updateStatus());
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+          this.updateStatus();
+        }
+      });
+      this.restoreDraft();
+      this.updateUI();
+    }
+
+    restoreDraft() {
+      if (this.restored) return;
+      const draft = this.store.getActiveDraft();
+      if (!draft) return;
+      this.activeRoute = {
+        ...draft,
+        track: (draft.track || []).slice(),
+        waypoints: (draft.waypoints || []).slice(),
+      };
+      this.state = draft.status || 'paused';
+      this.lastPoint = this.activeRoute.track.length ? this.activeRoute.track[this.activeRoute.track.length - 1] : null;
+      this.restored = true;
+      if (this.state === 'recording') {
+        this.startWatch();
+      }
+    }
+
+    toggle() {
+      if (this.state === 'idle') {
+        this.start();
+      } else if (this.state === 'recording') {
+        this.pause();
+      } else if (this.state === 'paused') {
+        this.resume();
+      }
+    }
+
+    async start() {
+      if (!navigator.geolocation) {
+        alert('この端末では位置情報を取得できません。');
+        return;
+      }
+      try {
+        const permission = await this.checkPermission();
+        if (permission === 'denied') {
+          this.showPermissionFallback();
+          return;
+        }
+      } catch (error) {
+        console.warn('Permission check failed', error);
+      }
+      const route = {
+        id: generateId('route'),
+        startAt: Date.now(),
+        endAt: null,
+        status: 'recording',
+        distance: 0,
+        durationMs: 0,
+        track: [],
+        waypoints: [],
+        metadata: {
+          type: '走行',
+          memo: '',
+          tags: [],
+          startNote: '',
+          endNote: '',
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      this.activeRoute = route;
+      this.state = 'recording';
+      this.lastPoint = null;
+      this.store.saveActiveDraft(route);
+      this.startWatch();
+      this.updateUI();
+      document.dispatchEvent(new CustomEvent('runlog:recording-started', { detail: { routeId: route.id } }));
+    }
+
+    async checkPermission() {
+      if (!navigator.permissions || !navigator.permissions.query) return 'prompt';
+      try {
+        const status = await navigator.permissions.query({ name: 'geolocation' });
+        if (status.state === 'denied') return 'denied';
+        if (status.state === 'granted') return 'granted';
+        return 'prompt';
+      } catch (error) {
+        console.warn('permissions.query failed', error);
+        return 'prompt';
+      }
+    }
+
+    showPermissionFallback() {
+      const message = [
+        '位置情報の権限が必要です。',
+        '設定アプリで「位置情報」→本アプリを選択し「常に許可」または「使用中のみ許可」を有効にしてください。',
+        '背景で継続取得する場合は電池最適化の除外設定も併せてご確認ください。',
+      ].join('\n');
+      alert(message);
+    }
+
+    startWatch() {
+      if (!navigator.geolocation) return;
+      if (this.watchId !== null) {
+        navigator.geolocation.clearWatch(this.watchId);
+      }
+      const options = {
+        enableHighAccuracy: true,
+        maximumAge: 5000,
+        timeout: 15000,
+      };
+      this.watchId = navigator.geolocation.watchPosition(
+        (pos) => this.handlePosition(pos),
+        (error) => {
+          console.warn('位置情報の取得に失敗しました', error);
+          this.crashReporter.capture(error, { type: 'geolocation', phase: 'watchPosition' });
+        },
+        options,
+      );
+      this.ensureTicker();
+    }
+
+    stopWatch() {
+      if (this.watchId !== null && navigator.geolocation) {
+        navigator.geolocation.clearWatch(this.watchId);
+      }
+      this.watchId = null;
+      this.clearTicker();
+    }
+
+    ensureTicker() {
+      if (this.statusInterval) return;
+      this.statusInterval = window.setInterval(() => this.updateStatus(), 1000);
+    }
+
+    clearTicker() {
+      if (this.statusInterval) {
+        window.clearInterval(this.statusInterval);
+        this.statusInterval = null;
+      }
+    }
+
+    pause() {
+      if (this.state !== 'recording') return;
+      this.state = 'paused';
+      this.stopWatch();
+      if (this.activeRoute) {
+        this.activeRoute.status = 'paused';
+        this.activeRoute.updatedAt = Date.now();
+        this.store.saveActiveDraft(this.activeRoute);
+      }
+      this.updateUI();
+      document.dispatchEvent(new CustomEvent('runlog:recording-paused', { detail: { routeId: this.activeRoute?.id } }));
+    }
+
+    resume() {
+      if (this.state !== 'paused') return;
+      this.state = 'recording';
+      if (this.activeRoute) {
+        this.activeRoute.status = 'recording';
+        this.activeRoute.updatedAt = Date.now();
+        this.store.saveActiveDraft(this.activeRoute);
+      }
+      this.startWatch();
+      this.updateUI();
+      document.dispatchEvent(new CustomEvent('runlog:recording-resumed', { detail: { routeId: this.activeRoute?.id } }));
+    }
+
+    stop() {
+      if (!this.activeRoute) return;
+      if (this.state === 'idle') return;
+      this.stopWatch();
+      const now = Date.now();
+      this.activeRoute.endAt = now;
+      this.activeRoute.status = 'completed';
+      this.activeRoute.updatedAt = now;
+      this.activeRoute.durationMs = this.activeRoute.startAt ? Math.max(0, now - this.activeRoute.startAt) : 0;
+      if (this.activeRoute.track.length) {
+        const start = this.activeRoute.track[0];
+        const end = this.activeRoute.track[this.activeRoute.track.length - 1];
+        if (start && !this.activeRoute.metadata.startNote) {
+          this.activeRoute.metadata.startNote = `${start.lat.toFixed(5)}, ${start.lon.toFixed(5)}`;
+        }
+        if (end && !this.activeRoute.metadata.endNote) {
+          this.activeRoute.metadata.endNote = `${end.lat.toFixed(5)}, ${end.lon.toFixed(5)}`;
+        }
+      }
+      this.store.upsertRoute(this.activeRoute);
+      this.store.saveActiveDraft(null);
+      document.dispatchEvent(new CustomEvent('runlog:recording-stopped', { detail: { routeId: this.activeRoute.id } }));
+      this.activeRoute = null;
+      this.lastPoint = null;
+      this.state = 'idle';
+      this.updateUI();
+    }
+
+    addWaypoint() {
+      if (!this.activeRoute) return;
+      if (!this.activeRoute.track.length) {
+        alert('まだ位置が記録されていません。');
+        return;
+      }
+      const label = window.prompt('通過点のメモ（任意）を入力してください。', '');
+      const last = this.activeRoute.track[this.activeRoute.track.length - 1];
+      this.activeRoute.waypoints.push({
+        id: generateId('wp'),
+        lat: last.lat,
+        lon: last.lon,
+        time: last.time,
+        memo: label || '',
+      });
+      this.activeRoute.updatedAt = Date.now();
+      this.store.saveActiveDraft(this.activeRoute);
+      this.updateStatus();
+      document.dispatchEvent(new CustomEvent('runlog:waypoint-added', { detail: { routeId: this.activeRoute.id } }));
+    }
+
+    handlePosition(position) {
+      if (!this.activeRoute) return;
+      const coords = position.coords || {};
+      const latitude = Number(coords.latitude);
+      const longitude = Number(coords.longitude);
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return;
+      const point = {
+        lat: latitude,
+        lon: longitude,
+        speed: Number.isFinite(coords.speed) ? coords.speed : null,
+        bearing: Number.isFinite(coords.heading) ? coords.heading : null,
+        accuracy: Number.isFinite(coords.accuracy) ? coords.accuracy : null,
+        time: position.timestamp || Date.now(),
+        source: 'gps',
+      };
+      if (!this.shouldRecordPoint(point)) {
+        return;
+      }
+      this.commitPoint(point);
+      this.store.saveActiveDraft(this.activeRoute);
+      this.updateStatus();
+    }
+
+    shouldRecordPoint(point) {
+      if (!this.activeRoute) return false;
+      if (!this.activeRoute.track.length) return true;
+      const previous = this.activeRoute.track[this.activeRoute.track.length - 1];
+      const distance = haversineDistanceMeters(previous.lat, previous.lon, point.lat, point.lon);
+      const timeDiff = Math.abs(point.time - previous.time);
+      const prevBearing = previous.bearing ?? calculateBearing(previous.lat, previous.lon, point.lat, point.lon);
+      const nextBearing = point.bearing ?? prevBearing;
+      const angleDiff = Math.abs(prevBearing - nextBearing);
+      const normalizedAngle = angleDiff > 180 ? 360 - angleDiff : angleDiff;
+      if (distance >= MIN_SAMPLE_DISTANCE_M) return true;
+      if (timeDiff >= MIN_SAMPLE_TIME_MS) return true;
+      if (normalizedAngle >= MIN_SAMPLE_ANGLE_DEG) return true;
+      return false;
+    }
+
+    commitPoint(point) {
+      if (!this.activeRoute) return;
+      const track = this.activeRoute.track;
+      if (track.length) {
+        const prev = track[track.length - 1];
+        const distance = haversineDistanceMeters(prev.lat, prev.lon, point.lat, point.lon);
+        if (distance > 0) {
+          this.activeRoute.distance += distance;
+        }
+        const timeDiff = Math.abs(point.time - prev.time);
+        if (distance >= LARGE_GAP_DISTANCE_M && timeDiff >= LARGE_GAP_TIME_MS) {
+          const segments = Math.min(3, Math.max(1, Math.round(distance / LARGE_GAP_DISTANCE_M)));
+          for (let i = 1; i < segments; i += 1) {
+            const ratio = i / segments;
+            track.push({
+              lat: prev.lat + (point.lat - prev.lat) * ratio,
+              lon: prev.lon + (point.lon - prev.lon) * ratio,
+              time: prev.time + (point.time - prev.time) * ratio,
+              speed: null,
+              bearing: calculateBearing(prev.lat, prev.lon, point.lat, point.lon),
+              accuracy: null,
+              source: 'interpolated',
+            });
+          }
+        }
+      }
+      track.push(point);
+      this.lastPoint = point;
+      if (!this.activeRoute.waypoints.length) {
+        this.activeRoute.waypoints.push({ id: generateId('wp'), lat: point.lat, lon: point.lon, time: point.time, memo: '開始地点' });
+      }
+      this.activeRoute.durationMs = this.activeRoute.startAt ? Math.max(0, point.time - this.activeRoute.startAt) : 0;
+      this.activeRoute.updatedAt = Date.now();
+    }
+
+    updateUI() {
+      this.updateButtons();
+      this.updateStatus();
+    }
+
+    updateButtons() {
+      if (!this.recordBtn) return;
+      if (this.state === 'idle') {
+        this.recordBtn.textContent = 'ルート記録開始';
+        if (this.stopBtn) this.stopBtn.hidden = true;
+        if (this.waypointBtn) this.waypointBtn.hidden = true;
+      } else if (this.state === 'recording') {
+        this.recordBtn.textContent = '一時停止';
+        if (this.stopBtn) this.stopBtn.hidden = false;
+        if (this.waypointBtn) this.waypointBtn.hidden = false;
+      } else if (this.state === 'paused') {
+        this.recordBtn.textContent = '再開';
+        if (this.stopBtn) this.stopBtn.hidden = false;
+        if (this.waypointBtn) this.waypointBtn.hidden = true;
+      }
+    }
+
+    updateStatus() {
+      if (!this.statusEl) return;
+      if (!this.activeRoute) {
+        this.statusEl.textContent = navigator.onLine ? '未記録' : '未記録（オフライン）';
+        return;
+      }
+      const duration = this.activeRoute.durationMs || (this.activeRoute.startAt ? Math.max(0, Date.now() - this.activeRoute.startAt) : 0);
+      const distance = this.activeRoute.distance || 0;
+      const pointCount = this.activeRoute.track.length;
+      const base = `${formatDistance(distance)} / ${formatDuration(duration)} / ${pointCount}点`;
+      if (this.state === 'recording') {
+        this.statusEl.textContent = navigator.onLine ? `記録中: ${base}` : `記録中(オフライン): ${base}`;
+      } else if (this.state === 'paused') {
+        this.statusEl.textContent = `一時停止中: ${base}`;
+      } else {
+        this.statusEl.textContent = base;
+      }
+    }
+  }
+
+  class RouteHistoryView {
+    constructor(store) {
+      this.store = store;
+      this.selectedRouteId = null;
+      this.filters = {
+        range: 'all',
+        startDate: null,
+        endDate: null,
+        tags: new Set(),
+        search: '',
+      };
+      this.listEl = null;
+      this.summaryEl = null;
+      this.detailsEl = null;
+      this.selection = new Set();
+    }
+
+    init() {
+      const button = document.getElementById('btnHistory');
+      if (button) {
+        button.addEventListener('click', () => this.show());
+      }
+      document.addEventListener('runlog:routes-changed', () => {
+        if (this.listEl) {
+          this.refresh();
+        }
+      });
+    }
+
+    show() {
+      const content = document.getElementById('content');
+      if (!content) return;
+      content.innerHTML = this.template();
+      this.cacheElements();
+      this.bindControls();
+      this.refresh();
+    }
+
+    template() {
+      return `
+        <section class="history-container">
+          <h2>履歴</h2>
+          <div class="history-controls">
+            <div class="history-control-group">
+              <label>期間
+                <select id="historyRange">
+                  <option value="all">全件</option>
+                  <option value="day">日別</option>
+                  <option value="week">週別</option>
+                  <option value="month">月別</option>
+                </select>
+              </label>
+              <label>開始日<input type="date" id="historyStart"></label>
+              <label>終了日<input type="date" id="historyEnd"></label>
+            </div>
+            <div class="history-control-group">
+              <label>タグ
+                <input type="text" id="historyTags" placeholder="例: 積込,乗船">
+              </label>
+              <label>検索
+                <input type="search" id="historySearch" placeholder="地点名・メモ・タグで検索">
+              </label>
+            </div>
+            <div class="history-actions">
+              <button type="button" id="historyExportGPX">選択GPX</button>
+              <button type="button" id="historyExportCSV">選択CSV</button>
+              <button type="button" id="historySaveDrafts" disabled>保存</button>
+              <button type="button" id="historyUndo" disabled>取り消し</button>
+              <button type="button" id="historyRedo" disabled>やり直し</button>
+            </div>
+          </div>
+          <div id="historySummary" class="history-summary"></div>
+          <div class="history-content">
+            <div id="historyList" class="history-list" aria-live="polite"></div>
+            <div id="historyDetails" class="history-details" aria-live="polite"></div>
+          </div>
+        </section>
+      `;
+    }
+
+    cacheElements() {
+      this.listEl = document.getElementById('historyList');
+      this.summaryEl = document.getElementById('historySummary');
+      this.detailsEl = document.getElementById('historyDetails');
+    }
+
+    bindControls() {
+      const rangeEl = document.getElementById('historyRange');
+      const startEl = document.getElementById('historyStart');
+      const endEl = document.getElementById('historyEnd');
+      const tagEl = document.getElementById('historyTags');
+      const searchEl = document.getElementById('historySearch');
+      if (rangeEl) {
+        rangeEl.value = this.filters.range;
+        rangeEl.addEventListener('change', () => {
+          this.filters.range = rangeEl.value;
+          this.refresh();
+        });
+      }
+      if (startEl) {
+        startEl.value = formatDateInputValue(this.filters.startDate);
+        startEl.addEventListener('change', () => {
+          this.filters.startDate = startEl.value ? new Date(startEl.value).getTime() : null;
+          this.refresh();
+        });
+      }
+      if (endEl) {
+        endEl.value = formatDateInputValue(this.filters.endDate);
+        endEl.addEventListener('change', () => {
+          this.filters.endDate = endEl.value ? new Date(endEl.value).getTime() + 86400000 - 1 : null;
+          this.refresh();
+        });
+      }
+      if (tagEl) {
+        tagEl.value = [...this.filters.tags].join(',');
+        tagEl.addEventListener('input', () => {
+          const tags = tagEl.value.split(',').map((tag) => tag.trim()).filter(Boolean);
+          this.filters.tags = new Set(tags);
+          this.refresh();
+        });
+      }
+      if (searchEl) {
+        searchEl.value = this.filters.search;
+        searchEl.addEventListener('input', () => {
+          this.filters.search = searchEl.value.trim();
+          this.refresh();
+        });
+      }
+      const gpxBtn = document.getElementById('historyExportGPX');
+      if (gpxBtn) gpxBtn.addEventListener('click', () => this.exportSelected('gpx'));
+      const csvBtn = document.getElementById('historyExportCSV');
+      if (csvBtn) csvBtn.addEventListener('click', () => this.exportSelected('csv'));
+      const saveBtn = document.getElementById('historySaveDrafts');
+      if (saveBtn) saveBtn.addEventListener('click', () => this.saveDrafts());
+      const undoBtn = document.getElementById('historyUndo');
+      if (undoBtn) undoBtn.addEventListener('click', () => this.undo());
+      const redoBtn = document.getElementById('historyRedo');
+      if (redoBtn) redoBtn.addEventListener('click', () => this.redo());
+    }
+
+    refresh() {
+      if (!this.summaryEl || !this.listEl) return;
+      const routes = this.applyFilters(this.store.getRoutes());
+      const totals = this.calculateTotals(routes);
+      const avgSpeed = totals.duration > 0 ? (totals.distance / 1000) / (totals.duration / 3600000) : 0;
+      this.summaryEl.innerHTML = `
+        <div>件数: <strong>${routes.length}</strong></div>
+        <div>合計距離: <strong>${formatDistance(totals.distance)}</strong></div>
+        <div>走行時間: <strong>${formatDuration(totals.duration)}</strong></div>
+        <div>平均速度: <strong>${avgSpeed.toFixed(1)} km/h</strong></div>
+      `;
+      this.renderList(routes);
+      this.updateActions();
+      if (this.selectedRouteId) {
+        const exists = routes.some((route) => route.id === this.selectedRouteId);
+        if (!exists && this.detailsEl) {
+          this.detailsEl.innerHTML = '';
+          this.selectedRouteId = null;
+        }
+      }
+    }
+
+    applyFilters(routes) {
+      return routes.filter((route) => {
+        if (this.filters.startDate && route.startAt < this.filters.startDate) return false;
+        if (this.filters.endDate && route.startAt > this.filters.endDate) return false;
+        if (this.filters.tags.size) {
+          const routeTags = new Set((route.metadata?.tags || []).map((tag) => tag.trim()));
+          let matched = false;
+          this.filters.tags.forEach((tag) => {
+            if (routeTags.has(tag)) matched = true;
+          });
+          if (!matched) return false;
+        }
+        if (this.filters.search) {
+          const text = [
+            route.metadata?.memo || '',
+            route.metadata?.startNote || '',
+            route.metadata?.endNote || '',
+            (route.metadata?.tags || []).join(','),
+          ].join(' ').toLowerCase();
+          if (!text.includes(this.filters.search.toLowerCase())) return false;
+        }
+        return true;
+      });
+    }
+
+    calculateTotals(routes) {
+      return routes.reduce((acc, route) => {
+        acc.distance += route.distance || 0;
+        acc.duration += route.durationMs || (route.endAt && route.startAt ? Math.max(0, route.endAt - route.startAt) : 0);
+        return acc;
+      }, { distance: 0, duration: 0 });
+    }
+
+    renderList(routes) {
+      if (!this.listEl) return;
+      if (!routes.length) {
+        this.listEl.innerHTML = '<p>記録がありません。</p>';
+        return;
+      }
+      const drafts = this.store.editDrafts || {};
+      this.listEl.innerHTML = routes.map((route) => {
+        const selected = this.selection.has(route.id);
+        const unsaved = drafts[route.id] ? '<span class="history-unsaved">●未保存</span>' : '';
+        return `
+          <div class="history-item" data-route-id="${route.id}">
+            <label class="history-item-select">
+              <input type="checkbox" data-role="select" ${selected ? 'checked' : ''}>
+            </label>
+            <button type="button" class="history-item-open" data-role="open">詳細</button>
+            <div class="history-item-body">
+              <div class="history-item-title">${formatDateTime(route.startAt)}</div>
+              <div class="history-item-meta">${formatDistance(route.distance)} / ${formatDuration(route.durationMs)}</div>
+            </div>
+            ${unsaved}
+          </div>
+        `;
+      }).join('');
+      this.listEl.querySelectorAll('.history-item').forEach((item) => {
+        const routeId = item.getAttribute('data-route-id');
+        const select = item.querySelector('input[data-role="select"]');
+        const openBtn = item.querySelector('button[data-role="open"]');
+        if (select) {
+          select.addEventListener('change', () => {
+            if (select.checked) {
+              this.selection.add(routeId);
+            } else {
+              this.selection.delete(routeId);
+            }
+            this.updateActions();
+          });
+        }
+        if (openBtn) {
+          openBtn.addEventListener('click', () => this.openDetails(routeId));
+        }
+      });
+    }
+
+    openDetails(routeId) {
+      this.selectedRouteId = routeId;
+      const route = this.store.getRoutes().find((item) => item.id === routeId);
+      if (!route || !this.detailsEl) return;
+      const draft = this.store.getEditDraft(routeId) || {};
+      const merged = {
+        ...route,
+        metadata: {
+          ...route.metadata,
+          ...draft,
+          tags: draft.tags || route.metadata?.tags || [],
+        },
+      };
+      const tagsText = (merged.metadata.tags || []).join(', ');
+      this.detailsEl.innerHTML = `
+        <article class="history-detail">
+          <header>
+            <h3>${formatDateTime(merged.startAt)} → ${formatDateTime(merged.endAt)}</h3>
+            <div>${formatDistance(merged.distance)} / ${formatDuration(merged.durationMs)}</div>
+          </header>
+          <section class="history-detail-grid">
+            <label>種別
+              <select id="routeType">
+                ${['走行', '積込', '乗船', '休憩', 'その他'].map((type) => `<option value="${type}" ${merged.metadata.type === type ? 'selected' : ''}>${type}</option>`).join('')}
+              </select>
+            </label>
+            <label>タグ
+              <input type="text" id="routeTags" value="${tagsText}">
+            </label>
+            <label>開始メモ
+              <input type="text" id="routeStartNote" value="${merged.metadata.startNote || ''}">
+            </label>
+            <label>終了メモ
+              <input type="text" id="routeEndNote" value="${merged.metadata.endNote || ''}">
+            </label>
+            <label class="history-detail-full">メモ
+              <textarea id="routeMemo" rows="4">${merged.metadata.memo || ''}</textarea>
+            </label>
+          </section>
+          <section class="history-detail-actions">
+            <button type="button" id="routeNavBtn">この経路でナビ</button>
+            <button type="button" id="routeReplayBtn">ルート再生</button>
+            <label>速度
+              <input type="range" id="routeReplaySpeed" min="0.5" max="3" step="0.5" value="1">
+            </label>
+          </section>
+          <section>
+            <canvas id="routeReplayCanvas" width="360" height="360" class="history-replay-canvas"></canvas>
+          </section>
+          <section>
+            <h4>トラックポイント (${merged.track.length}点)</h4>
+            <div class="history-track-list">${this.renderTrackTable(merged.track)}</div>
+          </section>
+        </article>
+      `;
+      this.bindDetails(merged);
+      this.updateActions();
+    }
+
+    renderTrackTable(track) {
+      if (!track.length) return '<p>データがありません。</p>';
+      const header = '<div class="history-track-row history-track-header"><span>時刻</span><span>緯度</span><span>経度</span><span>速度(km/h)</span></div>';
+      const rows = track.slice(0, 1000).map((point) => {
+        const speed = Number.isFinite(point.speed) ? (point.speed * 3.6).toFixed(1) : '-';
+        return `<div class="history-track-row"><span>${formatDateTime(point.time)}</span><span>${point.lat.toFixed(5)}</span><span>${point.lon.toFixed(5)}</span><span>${speed}</span></div>`;
+      }).join('');
+      return header + rows;
+    }
+
+    bindDetails(route) {
+      const typeEl = document.getElementById('routeType');
+      const tagsEl = document.getElementById('routeTags');
+      const startEl = document.getElementById('routeStartNote');
+      const endEl = document.getElementById('routeEndNote');
+      const memoEl = document.getElementById('routeMemo');
+      const navBtn = document.getElementById('routeNavBtn');
+      const replayBtn = document.getElementById('routeReplayBtn');
+      const speedEl = document.getElementById('routeReplaySpeed');
+      if (typeEl) typeEl.addEventListener('change', () => this.applyEdit(route.id, { type: typeEl.value }));
+      if (tagsEl) tagsEl.addEventListener('input', () => this.applyEdit(route.id, { tags: tagsEl.value.split(',').map((tag) => tag.trim()).filter(Boolean) }));
+      if (startEl) startEl.addEventListener('input', () => this.applyEdit(route.id, { startNote: startEl.value }));
+      if (endEl) endEl.addEventListener('input', () => this.applyEdit(route.id, { endNote: endEl.value }));
+      if (memoEl) memoEl.addEventListener('input', () => this.applyEdit(route.id, { memo: memoEl.value }));
+      if (navBtn) navBtn.addEventListener('click', () => this.openNavigation(route));
+      if (replayBtn) replayBtn.addEventListener('click', () => this.startReplay(route));
+      if (speedEl) speedEl.addEventListener('input', () => this.startReplay(route));
+      this.startReplay(route);
+    }
+
+    applyEdit(routeId, patch) {
+      const current = this.store.getEditDraft(routeId) || {};
+      const next = { ...current, ...patch };
+      const history = this.store.getUndoState(routeId);
+      history.undo.push(current);
+      history.redo = [];
+      this.store.saveUndoState(routeId, history);
+      this.store.setEditDraft(routeId, next);
+      this.updateActions();
+      this.refresh();
+    }
+
+    saveDrafts() {
+      const drafts = this.store.editDrafts || {};
+      Object.entries(drafts).forEach(([routeId, patch]) => {
+        const route = this.store.getRoutes().find((item) => item.id === routeId);
+        if (!route) return;
+        const updated = {
+          ...route,
+          metadata: {
+            ...route.metadata,
+            ...patch,
+            tags: patch.tags || route.metadata?.tags || [],
+          },
+          updatedAt: Date.now(),
+        };
+        this.store.upsertRoute(updated);
+        this.store.setEditDraft(routeId, null);
+        this.store.saveUndoState(routeId, { undo: [], redo: [] });
+      });
+      this.updateActions();
+      this.refresh();
+    }
+
+    undo() {
+      if (!this.selectedRouteId) return;
+      const history = this.store.getUndoState(this.selectedRouteId);
+      if (!history.undo.length) return;
+      const current = this.store.getEditDraft(this.selectedRouteId) || {};
+      const previous = history.undo.pop();
+      history.redo.push(current);
+      this.store.saveUndoState(this.selectedRouteId, history);
+      this.store.setEditDraft(this.selectedRouteId, previous);
+      this.refresh();
+    }
+
+    redo() {
+      if (!this.selectedRouteId) return;
+      const history = this.store.getUndoState(this.selectedRouteId);
+      if (!history.redo.length) return;
+      const current = this.store.getEditDraft(this.selectedRouteId) || {};
+      const next = history.redo.pop();
+      history.undo.push(current);
+      this.store.saveUndoState(this.selectedRouteId, history);
+      this.store.setEditDraft(this.selectedRouteId, next);
+      this.refresh();
+    }
+
+    updateActions() {
+      const drafts = this.store.editDrafts || {};
+      const saveBtn = document.getElementById('historySaveDrafts');
+      const undoBtn = document.getElementById('historyUndo');
+      const redoBtn = document.getElementById('historyRedo');
+      if (saveBtn) saveBtn.disabled = !Object.keys(drafts).length;
+      if (undoBtn) {
+        const history = this.store.getUndoState(this.selectedRouteId);
+        undoBtn.disabled = !history.undo.length;
+      }
+      if (redoBtn) {
+        const history = this.store.getUndoState(this.selectedRouteId);
+        redoBtn.disabled = !history.redo.length;
+      }
+    }
+
+    exportSelected(format) {
+      if (!this.selection.size) {
+        alert('エクスポートする経路を選択してください。');
+        return;
+      }
+      const routes = this.store.getRoutes().filter((route) => this.selection.has(route.id));
+      if (!routes.length) return;
+      if (format === 'gpx') {
+        const gpx = this.buildGPX(routes);
+        this.downloadFile('routes.gpx', gpx, 'application/gpx+xml');
+      } else {
+        const csv = this.buildCSV(routes);
+        this.downloadFile('routes.csv', csv, 'text/csv');
+      }
+    }
+
+    buildGPX(routes) {
+      const tracks = routes.map((route) => {
+        const points = route.track.map((point) => `      <trkpt lat="${point.lat}" lon="${point.lon}">
+        <time>${new Date(point.time).toISOString()}</time>
+      </trkpt>`).join('\n');
+        return `  <trk>
+      <name>${formatDateTime(route.startAt)}</name>
+${points}
+    </trk>`;
+      }).join('\n');
+      return `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Runlog">
+${tracks}
+</gpx>`;
+    }
+
+    buildCSV(routes) {
+      const header = ['routeId', 'timestamp', 'lat', 'lon', 'speed(km/h)'];
+      const rows = [header.join(',')];
+      routes.forEach((route) => {
+        route.track.forEach((point) => {
+          rows.push([
+            csvEscape(route.id),
+            csvEscape(new Date(point.time).toISOString()),
+            point.lat,
+            point.lon,
+            Number.isFinite(point.speed) ? (point.speed * 3.6).toFixed(2) : '',
+          ].join(','));
+        });
+      });
+      return rows.join('\n');
+    }
+
+    downloadFile(filename, data, type) {
+      const blob = new Blob([data], { type: type || 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      link.click();
+      setTimeout(() => URL.revokeObjectURL(url), 2000);
+    }
+
+    openNavigation(route) {
+      if (!route.track.length) {
+        alert('位置データがありません。');
+        return;
+      }
+      const origin = route.track[0];
+      const destination = route.track[route.track.length - 1];
+      const waypoints = this.buildWaypoints(route);
+      const params = new URLSearchParams({
+        api: '1',
+        origin: `${origin.lat},${origin.lon}`,
+        destination: `${destination.lat},${destination.lon}`,
+        travelmode: 'driving',
+      });
+      if (waypoints.length) {
+        params.set('waypoints', waypoints.map((wp) => `${wp.lat},${wp.lon}`).join('|'));
+      }
+      window.open(`https://www.google.com/maps/dir/?${params.toString()}`);
+    }
+
+    buildWaypoints(route) {
+      const waypoints = [...(route.waypoints || [])];
+      if (!waypoints.length) {
+        const track = route.track || [];
+        if (track.length <= 2) return [];
+        const step = Math.max(1, Math.floor(track.length / MAX_NAV_WAYPOINTS));
+        for (let i = step; i < track.length - 1; i += step) {
+          waypoints.push({ lat: track[i].lat, lon: track[i].lon });
+          if (waypoints.length >= MAX_NAV_WAYPOINTS) break;
+        }
+      }
+      return waypoints.slice(0, MAX_NAV_WAYPOINTS);
+    }
+
+    startReplay(route) {
+      const canvas = document.getElementById('routeReplayCanvas');
+      const speedEl = document.getElementById('routeReplaySpeed');
+      if (!canvas || !canvas.getContext) return;
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const track = route.track || [];
+      if (track.length < 2) {
+        ctx.fillStyle = '#64748b';
+        ctx.font = '16px sans-serif';
+        ctx.fillText('ポイント不足', 20, canvas.height / 2);
+        return;
+      }
+      const bounds = track.reduce((acc, point) => {
+        acc.minLat = Math.min(acc.minLat, point.lat);
+        acc.maxLat = Math.max(acc.maxLat, point.lat);
+        acc.minLon = Math.min(acc.minLon, point.lon);
+        acc.maxLon = Math.max(acc.maxLon, point.lon);
+        return acc;
+      }, { minLat: Infinity, maxLat: -Infinity, minLon: Infinity, maxLon: -Infinity });
+      const padding = 20;
+      const width = canvas.width - padding * 2;
+      const height = canvas.height - padding * 2;
+      const latSpan = Math.max(0.0001, bounds.maxLat - bounds.minLat);
+      const lonSpan = Math.max(0.0001, bounds.maxLon - bounds.minLon);
+      const scale = Math.min(width / lonSpan, height / latSpan);
+      const points = track.map((point) => ({
+        x: padding + (point.lon - bounds.minLon) * scale,
+        y: canvas.height - (padding + (point.lat - bounds.minLat) * scale),
+      }));
+      let progress = 0;
+      const speed = speedEl ? Number(speedEl.value) || 1 : 1;
+      const totalSegments = points.length - 1;
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = '#2563eb';
+      ctx.lineCap = 'round';
+      const draw = () => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.strokeStyle = '#94a3b8';
+        ctx.beginPath();
+        ctx.moveTo(points[0].x, points[0].y);
+        points.forEach((pt) => ctx.lineTo(pt.x, pt.y));
+        ctx.stroke();
+        const index = Math.floor(progress);
+        const partial = progress - index;
+        ctx.strokeStyle = '#2563eb';
+        ctx.beginPath();
+        ctx.moveTo(points[0].x, points[0].y);
+        for (let i = 1; i <= index && i < points.length; i += 1) {
+          ctx.lineTo(points[i].x, points[i].y);
+        }
+        if (index + 1 < points.length) {
+          const current = points[index];
+          const next = points[index + 1];
+          ctx.lineTo(
+            current.x + (next.x - current.x) * partial,
+            current.y + (next.y - current.y) * partial,
+          );
+        }
+        ctx.stroke();
+        ctx.fillStyle = '#ef4444';
+        const head = index + 1 < points.length ? points[index + 1] : points[points.length - 1];
+        ctx.beginPath();
+        ctx.arc(head.x, head.y, 6, 0, Math.PI * 2);
+        ctx.fill();
+        progress += 0.02 * speed;
+        if (progress < totalSegments) {
+          window.requestAnimationFrame(draw);
+        }
+      };
+      window.requestAnimationFrame(draw);
+    }
+
+    buildCSVSelection() {
+      return this.store.getRoutes().filter((route) => this.selection.has(route.id));
+    }
+  }
+
+  function setupHistoryButton(historyView) {
+    const button = document.getElementById('btnHistory');
+    if (button) {
+      button.addEventListener('click', () => historyView.show());
+    }
+  }
+
+  function bootstrap() {
+    appState.crashReporter = new CrashReporter();
+    appState.store = new RouteStore();
+    appState.splash = new SplashController();
+    appState.recorder = new RouteRecorder(appState.store, appState.crashReporter);
+    appState.history = new RouteHistoryView(appState.store);
+
+    appState.splash.attach();
+    appState.recorder.init();
+    appState.history.init();
+    setupHistoryButton(appState.history);
+
+    window.showRouteHistory = () => appState.history.show();
+    window.toggleRouteRecording = () => appState.recorder.toggle();
+
+    window.addEventListener('online', () => {
+      appState.crashReporter.flush();
+      appState.store.markSynced(() => false);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootstrap);
+  } else {
+    bootstrap();
+  }
+
+})();
+

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="manifest" href="./manifest.json">
   <link rel="stylesheet" href="./styles.css">
   <script src="./main.esc.js" defer></script>
+  <script src="./app-enhancements.js" defer></script>
   <meta name="theme-color" content="#0066cc">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -20,6 +21,13 @@
   <link rel="icon" href="./icons/icon-192.png">
 </head>
 <body>
+  <div id="splashScreen" class="splash-screen" role="status" aria-live="polite">
+    <div class="splash-content">
+      <img src="./icons/icon-192.png" alt="アプリのロゴ" width="96" height="96">
+      <p id="splashMessage">起動準備中...</p>
+      <button type="button" id="splashOfflineBtn" class="secondary" hidden>オフラインで開始</button>
+    </div>
+  </div>
   <header>
     <h1>運行管理(K)</h1>
   </header>
@@ -30,10 +38,17 @@
       </button>
       <div id="tripDayCounter" class="trip-day hidden" aria-live="polite"></div>
       <div id="statusIndicator" class="status-indicator status-inactive" aria-live="polite">停止中</div>
+      <div class="route-recorder">
+        <button id="btnRouteRecord" type="button" class="route-control">ルート記録開始</button>
+        <button id="btnRouteStop" type="button" class="route-control secondary" hidden>終了</button>
+        <button id="btnRouteWaypoint" type="button" class="route-control tertiary" hidden>通過点追加</button>
+        <div id="routeStatus" class="route-status" aria-live="polite">未記録</div>
+      </div>
       <button id="btnList" onclick="showList()">一覧</button>
       <button id="btnSummary" onclick="showSummary()">集計</button>
       <button id="btnByDate" onclick="showRecordsByDate()">日付別</button>
       <button id="btnDaily" onclick="showDailyReport()">日報</button>
+      <button id="btnHistory" type="button">履歴</button>
       <button id="btnExport" onclick="exportCSV()">CSV出力</button>
       <button id="btnMaintenance" onclick="showMaintenanceList()">整備記録</button>
       <button id="btnMapSettings" type="button">地図設定</button>

--- a/main.esc.js
+++ b/main.esc.js
@@ -3850,6 +3850,9 @@ window.addEventListener('load', () => {
   setupInstallButton();
   setupMapSettingsButton();
   schedulePendingGeocodeProcessing(800);
+  if (typeof document !== 'undefined' && typeof document.dispatchEvent === 'function') {
+    document.dispatchEvent(new CustomEvent('runlog:ready'));
+  }
 });
 
 ensureMapSettingsButtonBinding();
@@ -3864,6 +3867,7 @@ function applyJapaneseLabels() {
   setText('btnSummary', '集計');
   setText('btnByDate', '日付別');
   setText('btnDaily', '日報');
+  setText('btnHistory', '履歴');
   setText('btnExport', 'CSV出力');
   setText('btnMaintenance', '整備記録');
   setText('btnMapSettings', '地図設定');
@@ -3873,5 +3877,8 @@ function applyJapaneseLabels() {
   setText('btnFuel', '給油');
   setText('btnBreak', '休憩');
   setText('btnRest', '休息');
+  setText('btnRouteRecord', 'ルート記録開始');
+  setText('btnRouteStop', '終了');
+  setText('btnRouteWaypoint', '通過点追加');
   setText('statusIndicator', '停止中');
 }

--- a/main.js
+++ b/main.js
@@ -3916,6 +3916,9 @@ window.addEventListener('load', () => {
   setupInstallButton();
   setupMapSettingsButton();
   schedulePendingGeocodeProcessing(800);
+  if (typeof document !== 'undefined' && typeof document.dispatchEvent === 'function') {
+    document.dispatchEvent(new CustomEvent('runlog:ready'));
+  }
 });
 
 ensureMapSettingsButtonBinding();
@@ -3930,6 +3933,7 @@ function applyJapaneseLabels() {
   setText('btnSummary', '集計');
   setText('btnByDate', '日付別');
   setText('btnDaily', '日報');
+  setText('btnHistory', '履歴');
   setText('btnExport', 'CSV出力');
   setText('btnMaintenance', '整備記録');
   setText('btnMapSettings', '地図設定');
@@ -3939,5 +3943,8 @@ function applyJapaneseLabels() {
   setText('btnFuel', '給油');
   setText('btnBreak', '休憩');
   setText('btnRest', '休息');
+  setText('btnRouteRecord', 'ルート記録開始');
+  setText('btnRouteStop', '終了');
+  setText('btnRouteWaypoint', '通過点追加');
   setText('statusIndicator', '停止中');
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,6 +6,7 @@ const assetsToCache = [
   'styles.css',
   'main.esc.js',
   'main.js',
+  'app-enhancements.js',
   'manifest.json',
   'icons/icon-192.png',
   'icons/icon-512.png'

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,56 @@ nav {
   flex-wrap: wrap; /* allow buttons to wrap to the next line on narrow screens */
 }
 
+.splash-screen {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 24, 35, 0.9);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  z-index: 1000;
+  transition: opacity 0.3s ease;
+}
+
+.splash-screen.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.splash-content {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  padding: 2rem;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 12px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+.splash-content img {
+  border-radius: 22%;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+}
+
+#splashOfflineBtn {
+  padding: 0.65rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(0, 0, 0, 0.25);
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.2s ease;
+}
+
+#splashOfflineBtn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
 nav button {
   /* Increase padding and font size to create larger, easier to tap controls,
      following WCAG guidance for a minimum 44×44px touch target.
@@ -54,6 +104,251 @@ nav button {
   border-radius: 4px;
   cursor: pointer;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+
+.route-recorder {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.4rem;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 0.2rem;
+}
+
+.route-control {
+  background: #023e8a;
+  color: #fff;
+  font-weight: 600;
+}
+
+.route-control.secondary {
+  background: #d00000;
+}
+
+.route-control.tertiary {
+  background: #2b9348;
+}
+
+.route-control[hidden] {
+  display: none !important;
+}
+
+.route-status {
+  grid-column: 1 / -1;
+  background: #fff;
+  padding: 0.6rem 0.9rem;
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.history-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.history-controls {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+}
+
+.history-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-control-group label,
+.history-actions label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.history-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.history-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.5rem;
+  background: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  font-weight: 600;
+}
+
+.history-content {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1fr) minmax(20rem, 2fr);
+  gap: 1rem;
+}
+
+.history-list {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px rgba(15,23,42,0.05);
+  max-height: 65vh;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.history-item {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.history-item + .history-item {
+  margin-top: 0.3rem;
+}
+
+.history-item:hover {
+  background: #e2e8f0;
+}
+
+.history-item-select {
+  display: flex;
+  align-items: center;
+}
+
+.history-item-open {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+}
+
+.history-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.history-item-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.history-item-meta {
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.history-unsaved {
+  color: #dc2626;
+  font-weight: 700;
+}
+
+.history-details {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px rgba(15,23,42,0.05);
+  padding: 1rem;
+  max-height: 65vh;
+  overflow-y: auto;
+}
+
+.history-detail header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 0.8rem;
+}
+
+.history-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.history-detail-full {
+  grid-column: 1 / -1;
+}
+
+.history-detail label input,
+.history-detail label textarea,
+.history-detail label select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.history-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.history-replay-canvas {
+  width: 100%;
+  max-width: 420px;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.history-track-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.4rem;
+}
+
+.history-track-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(6rem, 1fr));
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  padding: 0.2rem 0.3rem;
+}
+
+.history-track-header {
+  font-weight: 700;
+  color: #0f172a;
+  border-bottom: 1px solid #cbd5f5;
+}
+
+@media (max-width: 900px) {
+  .history-content {
+    grid-template-columns: 1fr;
+  }
+
+  .history-details,
+  .history-list {
+    max-height: none;
+  }
 }
 
 nav .status-indicator {


### PR DESCRIPTION
## Summary
- add an offline-aware splash screen, crash reporter, and expose readiness events for safe startup fallback
- implement browser-based route recorder with adaptive sampling, waypoint capture, export, and replay tooling
- create a history workspace with filters, inline edits, undo/redo drafts, and Google Maps navigation integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6522d6a38832eaa5a973cadbd0ef7