### PR TITLE
Add dedicated route history navigation tab

### DIFF
--- a/app-enhancements.js
+++ b/app-enhancements.js
@@ -1339,7 +1339,13 @@ ${tracks}
   function setupHistoryButton(historyView) {
     const button = document.getElementById('btnHistory');
     if (button) {
-      button.addEventListener('click', () => historyView.show());
+      button.addEventListener('click', () => {
+        if (typeof window.navigateToRouteHistory === 'function') {
+          window.navigateToRouteHistory();
+        } else {
+          historyView.show();
+        }
+      });
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       <button id="btnSummary" onclick="showSummary()">集計</button>
       <button id="btnByDate" onclick="showRecordsByDate()">日付別</button>
       <button id="btnDaily" onclick="showDailyReport()">日報</button>
-      <button id="btnHistory" type="button">履歴</button>
+      <button id="btnHistory" type="button">ルート記録</button>
       <button id="btnExport" onclick="exportCSV()">CSV出力</button>
       <button id="btnMaintenance" onclick="showMaintenanceList()">整備記録</button>
       <button id="btnMapSettings" type="button">地図設定</button>

--- a/main.esc.js
+++ b/main.esc.js
@@ -2854,6 +2854,27 @@ function showRecordsByDate() {
   }
 }
 
+function navigateToRouteHistory() {
+  activeView = 'routes';
+  if (typeof window.showRouteHistory === 'function') {
+    window.showRouteHistory();
+    return;
+  }
+  const content = document.getElementById('content');
+  if (!content) return;
+  content.innerHTML = `
+    <section class="route-history route-history--unavailable">
+      <h2>ルート記録</h2>
+      <p>ルートや場所の記録を表示する機能が読み込まれていません。</p>
+      <p>ページを再読み込みするか、機能が有効かご確認ください。</p>
+    </section>
+  `;
+}
+
+if (typeof window !== 'undefined') {
+  window.navigateToRouteHistory = navigateToRouteHistory;
+}
+
 function recordEvent(type) {
   if (!currentTripStartTime) {
     alert('運行を開始してからイベントを記録してください。');
@@ -3794,6 +3815,31 @@ async function exportMaintenanceCSV() {
   summarizeExportResults(results, 'メンテナンス記録');
 }
 
+function refreshActiveView() {
+  switch (activeView) {
+    case 'list':
+      showList();
+      break;
+    case 'summary':
+      showSummary();
+      break;
+    case 'daily':
+      showDailyReport();
+      break;
+    case 'by-date':
+      showRecordsByDate();
+      break;
+    case 'maintenance':
+      showMaintenanceList();
+      break;
+    case 'routes':
+      navigateToRouteHistory();
+      break;
+    default:
+      break;
+  }
+}
+
 // Service Worker 登録
 function registerServiceWorker() {
   if ('serviceWorker' in navigator) {
@@ -3903,7 +3949,7 @@ function applyJapaneseLabels() {
   setText('btnSummary', '集計');
   setText('btnByDate', '日付別');
   setText('btnDaily', '日報');
-  setText('btnHistory', '履歴');
+  setText('btnHistory', 'ルート記録');
   setText('btnExport', 'CSV出力');
   setText('btnMaintenance', '整備記録');
   setText('btnMapSettings', '地図設定');

--- a/main.js
+++ b/main.js
@@ -2868,6 +2868,27 @@ function showRecordsByDate() {
   }
 }
 
+function navigateToRouteHistory() {
+  activeView = 'routes';
+  if (typeof window.showRouteHistory === 'function') {
+    window.showRouteHistory();
+    return;
+  }
+  const content = document.getElementById('content');
+  if (!content) return;
+  content.innerHTML = `
+    <section class="route-history route-history--unavailable">
+      <h2>ルート記録</h2>
+      <p>ルートや場所の記録を表示する機能が読み込まれていません。</p>
+      <p>ページを再読み込みするか、機能が有効かご確認ください。</p>
+    </section>
+  `;
+}
+
+if (typeof window !== 'undefined') {
+  window.navigateToRouteHistory = navigateToRouteHistory;
+}
+
 function recordEvent(type) {
   if (!currentTripStartTime) {
     alert('運行を開始してからイベントを記録してください。');
@@ -3963,6 +3984,9 @@ function refreshActiveView() {
     case 'maintenance':
       showMaintenanceList();
       break;
+    case 'routes':
+      navigateToRouteHistory();
+      break;
     default:
       break;
   }
@@ -4077,7 +4101,7 @@ function applyJapaneseLabels() {
   setText('btnSummary', '集計');
   setText('btnByDate', '日付別');
   setText('btnDaily', '日報');
-  setText('btnHistory', '履歴');
+  setText('btnHistory', 'ルート記録');
   setText('btnExport', 'CSV出力');
   setText('btnMaintenance', '整備記録');
   setText('btnMapSettings', '地図設定');

--- a/styles.css
+++ b/styles.css
@@ -200,6 +200,20 @@ nav button {
   gap: 1rem;
 }
 
+.route-history--unavailable {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(15,23,42,0.1);
+  padding: 2rem 1.5rem;
+  line-height: 1.7;
+  color: #0f172a;
+}
+
+.route-history--unavailable h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
 .history-list {
   background: #fff;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- rename the navigation tab to “ルート記録” and keep the label in sync during localization
- expose a global navigation helper that opens the recorded route/waypoint history view with an offline-safe fallback
- style the fallback state so the dedicated route history page remains readable even if the enhancements script is unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6622f2368832e905c38fa38a622f0