### PR TITLE
Add quick finish control for active tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,10 @@
         <span id="toggleLabel">運行開始</span>
       </button>
       <div id="tripDayCounter" class="trip-day hidden" aria-live="polite"></div>
-      <div id="statusIndicator" class="status-indicator status-inactive" aria-live="polite">停止中</div>
+      <div class="status-panel">
+        <div id="statusIndicator" class="status-indicator status-inactive" aria-live="polite">停止中</div>
+        <button id="btnFinishActiveTask" type="button" class="secondary hidden">作業終了</button>
+      </div>
       <div class="route-recorder">
         <button id="btnRouteRecord" type="button" class="route-control">ルート記録開始</button>
         <button id="btnRouteStop" type="button" class="route-control secondary" hidden>終了</button>

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,32 @@ nav button {
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 }
 
+.status-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.4rem;
+  min-width: 8.5rem;
+}
+
+.status-panel button {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+}
+
+.status-panel button.secondary {
+  background: #d00000;
+  color: #fff;
+}
+
+.status-panel button.secondary:disabled {
+  background: #f4a3a3;
+  color: #fff;
+  cursor: not-allowed;
+}
+
 .route-recorder {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));


### PR DESCRIPTION
## Summary
- add a dedicated finish button next to the current status indicator for active tasks
- update the status display logic to drive the new control and prevent duplicate submissions
- tweak navigation styles to accommodate the new status panel layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69b635834832ea70e9af017e8ee41